### PR TITLE
refactor: remove EPM compatibility shims

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -170,7 +170,7 @@ Boris Cherny (creator of Claude Code) keeps his team's file around 100 lines. Un
 Prefer single-file or single-test runs during iteration. Run the full suite before push.
 
 ### Layout
-- Backend/API: `jira_server.py`, `epm_home.py`, `epm_scope.py`, `planning/`
+- Backend/API: `jira_server.py`, `backend/epm/`, `backend/routes/`, `planning/`
 - Frontend source: `frontend/src/`, `jira-dashboard.html`
 - Generated frontend output: `frontend/dist/`
 - Tests: `tests/`, `tests/ui/`

--- a/backend/epm/home.py
+++ b/backend/epm/home.py
@@ -483,15 +483,7 @@ def build_teamwork_graph_client() -> HomeGraphQLClient:
         raise RuntimeError(
             "ATLASSIAN_EMAIL and ATLASSIAN_API_TOKEN (or JIRA_EMAIL/JIRA_TOKEN) must be set to use the EPM view"
         )
-    jira_url = ""
-    try:
-        import jira_server
-
-        jira_url = str(getattr(jira_server, "JIRA_URL", "") or "").rstrip("/")
-    except Exception:
-        jira_url = ""
-    if not jira_url:
-        jira_url = str(os.environ.get("JIRA_URL") or "").rstrip("/")
+    jira_url = get_configured_jira_url()
     if not jira_url:
         raise RuntimeError("JIRA_URL must be set to query Atlassian project tags")
     return HomeGraphQLClient(email, token, f"{jira_url}/gateway/api/graphql/twg")
@@ -629,16 +621,12 @@ def _container_id_from_cloud(cloud_id: str) -> str:
     return f"ari:cloud:townsquare::site/{cloud_id}"
 
 
-def fetch_home_site_cloud_id() -> str:
-    jira_url = ""
-    try:
-        import jira_server  # local import avoids circular import at module load time
+def get_configured_jira_url() -> str:
+    return str(os.environ.get("JIRA_URL") or "").rstrip("/")
 
-        jira_url = str(getattr(jira_server, "JIRA_URL", "") or "").rstrip("/")
-    except Exception:
-        jira_url = ""
-    if not jira_url:
-        jira_url = str(os.environ.get("JIRA_URL") or "").rstrip("/")
+
+def fetch_home_site_cloud_id() -> str:
+    jira_url = get_configured_jira_url()
     if not jira_url:
         raise RuntimeError("JIRA_URL must be set to detect the Atlassian site cloud ID")
     if jira_url in _CLOUD_ID_CACHE:

--- a/docs/plans/2026-05-01-codebase-structure-optimization.md
+++ b/docs/plans/2026-05-01-codebase-structure-optimization.md
@@ -30,8 +30,8 @@ cache behavior, and endpoint timing visibility.
 - `frontend/dist/dashboard.css` is treated as generated output, but it is also the
   only stylesheet source today.
 - Existing EPM extraction work is useful but incomplete:
-  `frontend/src/epm/*`, `epm_home.py`, `epm_scope.py`, and `epm_rollup.py`
-  should be expanded and then moved into the final backend package structure.
+  `frontend/src/epm/*` and `backend/epm/*` should be expanded into the final
+  frontend and backend package structure.
 
 ## Non-Goals
 
@@ -288,7 +288,6 @@ Owner: EPM frontend API worker.
 Write set:
 
 - `frontend/src/api/epmApi.js`
-- `frontend/src/epm/epmFetch.js`
 - `frontend/src/dashboard.jsx`
 - generated `frontend/dist/dashboard.js`
 - generated `frontend/dist/dashboard.js.map`
@@ -298,9 +297,8 @@ Write set:
 
 Steps:
 
-1. Move existing EPM wrapper logic from `frontend/src/epm/epmFetch.js` into
-   `frontend/src/api/epmApi.js`.
-2. Keep `frontend/src/epm/epmFetch.js` as a compatibility re-export for this phase.
+1. Ensure EPM wrapper logic lives in `frontend/src/api/epmApi.js`.
+2. Remove `frontend/src/epm/epmFetch.js` once imports use `frontend/src/api/epmApi.js`.
 3. Update dashboard imports if needed.
 4. Preserve URL construction, query params, `cache: 'no-cache'`, and error labels.
 
@@ -774,28 +772,19 @@ Write set:
 - `backend/epm/scope.py`
 - `backend/epm/rollup.py`
 - `backend/epm/projects.py`
-- root compatibility shims if retained:
-  - `epm_home.py`
-  - `epm_scope.py`
-  - `epm_rollup.py`
 - `jira_server.py`
 - EPM backend tests
 
 Shim strategy:
 
-Use one of these strategies and document the choice in the commit:
-
-- Preferred for lower churn: keep temporary root-level shim modules
-  (`epm_home.py`, `epm_scope.py`, `epm_rollup.py`) that re-export from
-  `backend.epm.*`, then remove shims in a later cleanup once imports are updated.
-- Preferred for a complete package move: update every import in one slice and add
-  source guards preventing root-level EPM modules from returning.
+Use the complete package move: update imports in one slice and keep source guards
+preventing root-level EPM modules from returning.
 
 Steps:
 
-1. Move `epm_home.py` to `backend/epm/home.py`.
-2. Move `epm_scope.py` to `backend/epm/scope.py`.
-3. Move `epm_rollup.py` to `backend/epm/rollup.py`.
+1. Ensure Home/Townsquare access lives in `backend/epm/home.py`.
+2. Ensure EPM JQL helpers live in `backend/epm/scope.py`.
+3. Ensure EPM rollup builders live in `backend/epm/rollup.py`.
 4. Extract EPM project payload/config resolution into `backend/epm/projects.py`.
 5. Preserve patch targets used by tests, either via shims or explicit test updates.
 

--- a/epm_home.py
+++ b/epm_home.py
@@ -1,6 +1,0 @@
-"""Compatibility shim for backend.epm.home."""
-
-import sys
-from backend.epm import home as _home
-
-sys.modules[__name__] = _home

--- a/epm_rollup.py
+++ b/epm_rollup.py
@@ -1,6 +1,0 @@
-"""Compatibility shim for backend.epm.rollup."""
-
-import sys
-from backend.epm import rollup as _rollup
-
-sys.modules[__name__] = _rollup

--- a/epm_scope.py
+++ b/epm_scope.py
@@ -1,6 +1,0 @@
-"""Compatibility shim for backend.epm.scope."""
-
-import sys
-from backend.epm import scope as _scope
-
-sys.modules[__name__] = _scope

--- a/frontend/src/epm/epmFetch.js
+++ b/frontend/src/epm/epmFetch.js
@@ -1,1 +1,0 @@
-export * from '../api/epmApi.js';

--- a/jira_server.py
+++ b/jira_server.py
@@ -26,10 +26,10 @@ from openpyxl.styles import Font, PatternFill, Alignment
 import io
 from requests import Session
 from concurrent.futures import ThreadPoolExecutor, as_completed, TimeoutError as FuturesTimeoutError
-import epm_home
-from epm_home import fetch_epm_home_projects, merge_epm_linkage
-from epm_rollup import EpmRollupDependencies, build_per_project_rollup
-from epm_scope import build_epm_scope_clause, normalize_epm_sprint_field, should_apply_epm_sprint
+from backend.epm import home as epm_home
+from backend.epm.home import fetch_epm_home_projects, merge_epm_linkage
+from backend.epm.rollup import EpmRollupDependencies, build_per_project_rollup
+from backend.epm.scope import build_epm_scope_clause, normalize_epm_sprint_field, should_apply_epm_sprint
 from planning import Issue, ScheduledIssue, ScenarioConfig, compute_slack, schedule_issues
 from backend.app import app
 from backend import config_store as _config_store
@@ -5520,6 +5520,7 @@ if __name__ == '__main__':
     # Apply CLI overrides while keeping env defaults as fallbacks
     if args.jira_url:
         JIRA_URL = args.jira_url
+        os.environ['JIRA_URL'] = args.jira_url
     if args.jira_email:
         JIRA_EMAIL = args.jira_email
     if args.jira_token:

--- a/tests/test_backend_route_source_guards.py
+++ b/tests/test_backend_route_source_guards.py
@@ -1,4 +1,3 @@
-import ast
 import re
 import sys
 import types
@@ -51,13 +50,6 @@ SETTINGS_ROUTE_PATHS = (
     "/api/boards",
     "/api/sprints",
 )
-APPROVED_ROOT_EPM_SHIMS = {
-    "epm_home.py",
-    "epm_scope.py",
-    "epm_rollup.py",
-}
-
-
 class FakeJiraResponse:
     def __init__(self, payload, status_code=200):
         self._payload = payload
@@ -66,15 +58,6 @@ class FakeJiraResponse:
 
     def json(self):
         return self._payload
-
-
-def top_level_definitions(source):
-    tree = ast.parse(source)
-    return [
-        node.name
-        for node in tree.body
-        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef))
-    ]
 
 
 def app_route_pattern(route_paths):
@@ -140,40 +123,15 @@ class BackendRouteSourceGuardTests(unittest.TestCase):
             "jira_server.py must not retain root @app.route decorators for settings/config/catalog routes after backend/routes/settings_routes.py exists",
         )
 
-    def test_root_epm_helpers_become_import_shims_after_backend_epm_package_exists(self):
+    def test_root_epm_helpers_do_not_return_after_backend_epm_package_exists(self):
         if not BACKEND_EPM_PATH.exists():
             return
 
         root_epm_files = sorted(REPO_ROOT.glob("epm_*.py"))
-        unexpected_helpers = [
-            path.name for path in root_epm_files
-            if path.name not in APPROVED_ROOT_EPM_SHIMS
-        ]
         self.assertEqual(
-            unexpected_helpers,
+            [path.name for path in root_epm_files],
             [],
-            "new root epm_*.py helpers are not allowed after backend/epm/ exists",
-        )
-
-        real_definition_files = []
-        non_backend_import_files = []
-        for path in root_epm_files:
-            source = path.read_text(encoding="utf8")
-            definitions = top_level_definitions(source)
-            if definitions:
-                real_definition_files.append(f"{path.name}: {', '.join(definitions)}")
-            if "backend.epm." not in source:
-                non_backend_import_files.append(path.name)
-
-        self.assertEqual(
-            real_definition_files,
-            [],
-            "approved root EPM shims must not keep real def/class definitions after backend/epm/ exists",
-        )
-        self.assertEqual(
-            non_backend_import_files,
-            [],
-            "approved root EPM shims must import or alias backend.epm.* after backend/epm/ exists",
+            "root epm_*.py compatibility modules must not return after backend/epm/ exists",
         )
 
     def test_epm_aggregate_route_forwards_rollup_headers_and_params(self):

--- a/tests/test_epm_home_api.py
+++ b/tests/test_epm_home_api.py
@@ -5,10 +5,9 @@ import time
 from urllib.error import HTTPError
 from unittest.mock import Mock, patch
 
-import epm_home
-import jira_server
+from backend.epm import home as epm_home
 
-from epm_home import (
+from backend.epm.home import (
     HomeGraphQLClient,
     bucket_epm_state,
     build_home_project_record,
@@ -173,8 +172,8 @@ class TestEpmHomeApi(unittest.TestCase):
         self.assertEqual(result, ['rnd_project_alpha', 'epm'])
         client.execute.assert_called_once_with(epm_home.QUERY_PROJECT_TAGS, {'projectId': 'proj-1'})
 
-    @patch('epm_home.fetch_home_site_cloud_id', return_value='cloud-123')
-    @patch('epm_home.build_teamwork_graph_client')
+    @patch('backend.epm.home.fetch_home_site_cloud_id', return_value='cloud-123')
+    @patch('backend.epm.home.build_teamwork_graph_client')
     def test_fetch_project_tags_falls_back_to_teamwork_graph_when_direct_tags_are_empty(self, mock_build_twg_client, mock_cloud_id):
         home_client = Mock()
         home_client.execute.return_value = {
@@ -216,8 +215,8 @@ class TestEpmHomeApi(unittest.TestCase):
         mock_cloud_id.assert_called_once_with()
         mock_build_twg_client.assert_called_once_with()
 
-    @patch('epm_home.fetch_home_site_cloud_id', return_value='cloud-123')
-    @patch('epm_home.build_teamwork_graph_client')
+    @patch('backend.epm.home.fetch_home_site_cloud_id', return_value='cloud-123')
+    @patch('backend.epm.home.build_teamwork_graph_client')
     def test_fetch_project_tags_falls_back_to_teamwork_graph_relationship(self, mock_build_twg_client, mock_cloud_id):
         home_client = Mock()
         home_client.execute.side_effect = epm_home.HomeGraphQLError('unknown field tags')
@@ -256,18 +255,18 @@ class TestEpmHomeApi(unittest.TestCase):
         with self.assertRaises(TypeError):
             fetch_epm_home_projects()
 
-    @patch('epm_home.logger.warning')
+    @patch('backend.epm.home.logger.warning')
     def test_fetch_epm_home_projects_returns_empty_when_scope_missing(self, mock_warning):
         self.assertEqual(fetch_epm_home_projects({}), [])
         mock_warning.assert_called_once_with('EPM home fetch skipped: subGoalKey is required')
 
-    @patch('epm_home.logger.warning')
+    @patch('backend.epm.home.logger.warning')
     def test_fetch_epm_home_projects_returns_empty_when_scope_is_malformed_truthy_value(self, mock_warning):
         self.assertEqual(fetch_epm_home_projects('bad-scope'), [])
         mock_warning.assert_called_once_with('EPM home fetch skipped: subGoalKey is required')
 
-    @patch('epm_home.build_home_graphql_client')
-    @patch('epm_home.logger.warning')
+    @patch('backend.epm.home.build_home_graphql_client')
+    @patch('backend.epm.home.logger.warning')
     def test_fetch_epm_home_projects_returns_empty_when_scope_values_are_non_string(self, mock_warning, mock_build_client):
         scope = {'subGoalKey': ['CHILD-200']}
 
@@ -276,9 +275,8 @@ class TestEpmHomeApi(unittest.TestCase):
         mock_warning.assert_called_once_with('EPM home fetch skipped: subGoalKey is required')
         mock_build_client.assert_not_called()
 
-    @patch.dict('os.environ', {'JIRA_URL': ''}, clear=False)
-    @patch.object(jira_server, 'JIRA_URL', 'https://example.atlassian.net')
-    @patch('epm_home.urlopen')
+    @patch.dict('os.environ', {'JIRA_URL': 'https://example.atlassian.net'}, clear=False)
+    @patch('backend.epm.home.urlopen')
     def test_fetch_home_site_cloud_id_uses_jira_tenant_info(self, mock_urlopen):
         response = Mock()
         response.__enter__ = Mock(return_value=response)
@@ -289,9 +287,8 @@ class TestEpmHomeApi(unittest.TestCase):
         self.assertEqual(fetch_home_site_cloud_id(), 'cloud-123')
         self.assertEqual(mock_urlopen.call_args[0][0].full_url, 'https://example.atlassian.net/_edge/tenant_info')
 
-    @patch.dict('os.environ', {'JIRA_URL': ''}, clear=False)
-    @patch.object(jira_server, 'JIRA_URL', 'https://cached.atlassian.net')
-    @patch('epm_home.urlopen')
+    @patch.dict('os.environ', {'JIRA_URL': 'https://cached.atlassian.net'}, clear=False)
+    @patch('backend.epm.home.urlopen')
     def test_fetch_home_site_cloud_id_is_cached_per_jira_url(self, mock_urlopen):
         response = Mock()
         response.__enter__ = Mock(return_value=response)
@@ -304,10 +301,9 @@ class TestEpmHomeApi(unittest.TestCase):
 
         self.assertEqual(mock_urlopen.call_count, 1)
 
-    @patch.dict('os.environ', {'JIRA_URL': ''}, clear=False)
-    @patch.object(jira_server, 'JIRA_URL', 'https://cli-override.atlassian.net')
-    @patch('epm_home.urlopen')
-    def test_fetch_home_site_cloud_id_prefers_jira_server_cli_override(self, mock_urlopen):
+    @patch.dict('os.environ', {'JIRA_URL': 'https://env-override.atlassian.net/'}, clear=False)
+    @patch('backend.epm.home.urlopen')
+    def test_fetch_home_site_cloud_id_strips_trailing_slash(self, mock_urlopen):
         response = Mock()
         response.__enter__ = Mock(return_value=response)
         response.__exit__ = Mock(return_value=False)
@@ -315,9 +311,9 @@ class TestEpmHomeApi(unittest.TestCase):
         mock_urlopen.return_value = response
 
         self.assertEqual(fetch_home_site_cloud_id(), 'cloud-456')
-        self.assertEqual(mock_urlopen.call_args[0][0].full_url, 'https://cli-override.atlassian.net/_edge/tenant_info')
+        self.assertEqual(mock_urlopen.call_args[0][0].full_url, 'https://env-override.atlassian.net/_edge/tenant_info')
 
-    @patch('epm_home.resolve_goal_by_key')
+    @patch('backend.epm.home.resolve_goal_by_key')
     def test_fetch_sub_goals_for_root_key_returns_non_archived_children(self, mock_resolve_goal):
         client = HomeGraphQLClient('user@example.com', 'token')
         client.execute_paginated = Mock(
@@ -332,11 +328,11 @@ class TestEpmHomeApi(unittest.TestCase):
 
         self.assertEqual(result, [{'id': 'goal-child', 'key': 'CHILD-200', 'name': 'Synthetic Child Goal', 'url': 'https://home/goal/child-200', 'isArchived': False}])
 
-    @patch('epm_home.extract_home_jira_linkage')
-    @patch('epm_home.fetch_latest_project_update')
-    @patch('epm_home.fetch_projects_for_goal')
-    @patch('epm_home.fetch_home_site_cloud_id')
-    @patch('epm_home.build_home_graphql_client')
+    @patch('backend.epm.home.extract_home_jira_linkage')
+    @patch('backend.epm.home.fetch_latest_project_update')
+    @patch('backend.epm.home.fetch_projects_for_goal')
+    @patch('backend.epm.home.fetch_home_site_cloud_id')
+    @patch('backend.epm.home.build_home_graphql_client')
     def test_fetch_epm_home_projects_resolves_child_sub_goal_from_root_children(
         self,
         mock_build_client,
@@ -382,12 +378,12 @@ class TestEpmHomeApi(unittest.TestCase):
         mock_fetch_projects.assert_called_once_with(client, 'goal-child')
         self.assertEqual(result[0]['name'], 'Synthetic Launch')
 
-    @patch('epm_home.extract_home_jira_linkage')
-    @patch('epm_home.fetch_latest_project_update')
-    @patch('epm_home.fetch_projects_for_goal')
-    @patch('epm_home.resolve_goal_by_key')
-    @patch('epm_home.fetch_home_site_cloud_id')
-    @patch('epm_home.build_home_graphql_client')
+    @patch('backend.epm.home.extract_home_jira_linkage')
+    @patch('backend.epm.home.fetch_latest_project_update')
+    @patch('backend.epm.home.fetch_projects_for_goal')
+    @patch('backend.epm.home.resolve_goal_by_key')
+    @patch('backend.epm.home.fetch_home_site_cloud_id')
+    @patch('backend.epm.home.build_home_graphql_client')
     def test_fetch_epm_home_projects_resolves_sub_goal_scope(
         self,
         mock_build_client,
@@ -469,8 +465,8 @@ class TestEpmHomeApi(unittest.TestCase):
         )
         self.assertEqual(result, [{'id': 'update-1', 'creationDate': '2026-04-12T10:00:00.000Z', 'summary': 'Latest status'}])
 
-    @patch('epm_home.fetch_latest_project_update')
-    @patch('epm_home.fetch_goal_project_links')
+    @patch('backend.epm.home.fetch_latest_project_update')
+    @patch('backend.epm.home.fetch_goal_project_links')
     def test_fetch_projects_for_goal_preserves_link_order_after_parallel_enrichment(self, mock_project_links, mock_fetch_update):
         client = Mock()
         mock_project_links.return_value = [
@@ -498,12 +494,12 @@ class TestEpmHomeApi(unittest.TestCase):
         client.execute.side_effect = execute
         mock_fetch_update.return_value = []
 
-        with patch('epm_home.fetch_project_tags', return_value=[]):
+        with patch('backend.epm.home.fetch_project_tags', return_value=[]):
             result = fetch_projects_for_goal(client, 'goal-1')
 
         self.assertEqual([row['homeProjectId'] for row in result], ['proj-slow', 'proj-fast', 'proj-medium'])
 
-    @patch('epm_home.fetch_goal_project_links')
+    @patch('backend.epm.home.fetch_goal_project_links')
     def test_fetch_projects_for_goal_uses_enriched_goal_project_rows_without_per_project_fetches(self, mock_project_links):
         client = Mock()
         client.execute.side_effect = AssertionError('enriched goal project rows should not need per-project Home calls')
@@ -536,8 +532,8 @@ class TestEpmHomeApi(unittest.TestCase):
             },
         ]
 
-        with patch('epm_home.fetch_latest_project_update') as mock_fetch_update, patch(
-            'epm_home.fetch_project_tags',
+        with patch('backend.epm.home.fetch_latest_project_update') as mock_fetch_update, patch(
+            'backend.epm.home.fetch_project_tags',
         ) as mock_fetch_tags:
             result = fetch_projects_for_goal(client, 'goal-1')
 
@@ -568,10 +564,10 @@ class TestEpmHomeApi(unittest.TestCase):
         self.assertIn('tags @optIn(to: "Townsquare")', query)
         self.assertIn('updates(first: 1)', query)
 
-    @patch('epm_home.fetch_goal_project_links')
-    @patch('epm_home.resolve_sub_goal_for_scope')
-    @patch('epm_home.fetch_home_site_cloud_id')
-    @patch('epm_home.build_home_graphql_client')
+    @patch('backend.epm.home.fetch_goal_project_links')
+    @patch('backend.epm.home.resolve_sub_goal_for_scope')
+    @patch('backend.epm.home.fetch_home_site_cloud_id')
+    @patch('backend.epm.home.build_home_graphql_client')
     def test_latest_update_fetches_share_bounded_fanout_and_home_projects_consumes_enriched_rows(
         self,
         mock_build_client,
@@ -617,8 +613,8 @@ class TestEpmHomeApi(unittest.TestCase):
                 release_updates.set()
             return [{'creationDate': '2026-04-12T10:00:00.000Z', 'summary': f'Update {project_id}'}]
 
-        with patch('epm_home.fetch_latest_project_update', side_effect=fetch_update) as mock_fetch_update, patch(
-            'epm_home.fetch_project_tags',
+        with patch('backend.epm.home.fetch_latest_project_update', side_effect=fetch_update) as mock_fetch_update, patch(
+            'backend.epm.home.fetch_project_tags',
             return_value=[],
         ):
             result = fetch_epm_home_projects({'subGoalKey': 'child-200'})
@@ -628,8 +624,8 @@ class TestEpmHomeApi(unittest.TestCase):
         self.assertEqual([row['homeProjectId'] for row in result], ['proj-a', 'proj-b'])
         self.assertEqual([row['latestUpdateSnippet'] for row in result], ['Update proj-a', 'Update proj-b'])
 
-        with patch('epm_home.fetch_projects_for_goal') as mock_fetch_projects, patch(
-            'epm_home.fetch_latest_project_update',
+        with patch('backend.epm.home.fetch_projects_for_goal') as mock_fetch_projects, patch(
+            'backend.epm.home.fetch_latest_project_update',
             side_effect=AssertionError('fetch_epm_home_projects must not fetch updates sequentially'),
         ) as mock_late_update:
             mock_fetch_projects.return_value = [
@@ -653,7 +649,7 @@ class TestEpmHomeApi(unittest.TestCase):
         mock_late_update.assert_not_called()
         self.assertEqual(result[0]['homeProjectId'], 'proj-enriched')
 
-    @patch('epm_home.logger.warning')
+    @patch('backend.epm.home.logger.warning')
     def test_fetch_goal_project_links_reads_more_than_200_projects(self, mock_warning):
         client = Mock()
 
@@ -693,7 +689,7 @@ class TestEpmHomeApi(unittest.TestCase):
                 self.assertEqual(variables['after'], f'cursor-{call_index}')
         mock_warning.assert_not_called()
 
-    @patch('epm_home.logger.warning')
+    @patch('backend.epm.home.logger.warning')
     def test_fetch_goal_project_links_caps_large_goal_fetches(self, mock_warning):
         client = Mock()
 
@@ -722,18 +718,20 @@ class TestEpmHomeApi(unittest.TestCase):
         mock_warning.assert_called_once()
         self.assertIn('truncated', mock_warning.call_args.args[0])
 
-    @patch('epm_home.fetch_home_site_cloud_id', side_effect=RuntimeError('Jira tenant_info did not return cloudId'))
-    @patch('epm_home.logger.warning')
-    def test_fetch_epm_home_projects_returns_empty_when_tenant_info_lookup_fails(self, mock_warning, mock_fetch_cloud_id):
+    @patch('backend.epm.home.fetch_home_site_cloud_id', side_effect=RuntimeError('Jira tenant_info did not return cloudId'))
+    @patch('backend.epm.home.build_home_graphql_client', return_value=Mock())
+    @patch('backend.epm.home.logger.warning')
+    def test_fetch_epm_home_projects_returns_empty_when_tenant_info_lookup_fails(self, mock_warning, mock_build_client, mock_fetch_cloud_id):
         self.assertEqual(fetch_epm_home_projects({'subGoalKey': 'child-200'}), [])
+        mock_build_client.assert_called_once_with()
         mock_fetch_cloud_id.assert_called_once_with()
         mock_warning.assert_called_once()
         self.assertEqual(mock_warning.call_args[0][0], 'EPM home fetch failed: %s')
         self.assertIsInstance(mock_warning.call_args[0][1], RuntimeError)
         self.assertEqual(str(mock_warning.call_args[0][1]), 'Jira tenant_info did not return cloudId')
 
-    @patch('epm_home.time.sleep')
-    @patch('epm_home.urlopen')
+    @patch('backend.epm.home.time.sleep')
+    @patch('backend.epm.home.urlopen')
     def test_execute_retries_429_after_retry_after_before_success(self, mock_urlopen, mock_sleep):
         transient_error = HTTPError(
             'https://team.atlassian.com/gateway/api/graphql',

--- a/tests/test_epm_rollup_builder.py
+++ b/tests/test_epm_rollup_builder.py
@@ -2,7 +2,7 @@ import threading
 import unittest
 
 import jira_server
-from epm_rollup import EpmRollupDependencies, build_per_project_rollup
+from backend.epm.rollup import EpmRollupDependencies, build_per_project_rollup
 
 
 class BuildPerProjectRollupTests(unittest.TestCase):

--- a/tests/test_epm_scope_resolution.py
+++ b/tests/test_epm_scope_resolution.py
@@ -2,7 +2,7 @@ import unittest
 from unittest.mock import patch
 
 import jira_server
-from epm_scope import build_epm_scope_clause, build_rollup_jqls, normalize_epm_sprint_field, should_apply_epm_sprint
+from backend.epm.scope import build_epm_scope_clause, build_rollup_jqls, normalize_epm_sprint_field, should_apply_epm_sprint
 
 
 class TestEpmScopeResolution(unittest.TestCase):

--- a/tests/test_epm_shell_source_guards.js
+++ b/tests/test_epm_shell_source_guards.js
@@ -5,7 +5,6 @@ const test = require('node:test');
 
 const dashboardPath = path.join(__dirname, '..', 'frontend', 'src', 'dashboard.jsx');
 const epmApiPath = path.join(__dirname, '..', 'frontend', 'src', 'api', 'epmApi.js');
-const epmFetchPath = path.join(__dirname, '..', 'frontend', 'src', 'epm', 'epmFetch.js');
 const epmViewDataPath = path.join(__dirname, '..', 'frontend', 'src', 'epm', 'useEpmViewData.js');
 const epmControlsPath = path.join(__dirname, '..', 'frontend', 'src', 'epm', 'EpmControls.jsx');
 const epmViewPath = path.join(__dirname, '..', 'frontend', 'src', 'epm', 'EpmView.jsx');
@@ -13,7 +12,6 @@ const epmRollupPanelPath = path.join(__dirname, '..', 'frontend', 'src', 'epm', 
 const helperPath = path.join(__dirname, '..', 'frontend', 'src', 'epm', 'epmProjectUtils.mjs');
 const dashboardSource = fs.readFileSync(dashboardPath, 'utf8');
 const epmApiSource = fs.existsSync(epmApiPath) ? fs.readFileSync(epmApiPath, 'utf8') : '';
-const epmFetchSource = fs.readFileSync(epmFetchPath, 'utf8');
 const epmViewDataSource = fs.existsSync(epmViewDataPath) ? fs.readFileSync(epmViewDataPath, 'utf8') : '';
 const epmControlsSource = fs.existsSync(epmControlsPath) ? fs.readFileSync(epmControlsPath, 'utf8') : '';
 const epmViewSource = fs.existsSync(epmViewPath) ? fs.readFileSync(epmViewPath, 'utf8') : '';
@@ -65,7 +63,6 @@ test('dashboard source wires EPM rollup loading and metadata-only rendering', ()
     assert.ok(epmApiSource.includes('const refreshParam = forceRefresh ? \'?refresh=true\' : \'\';'), 'Expected project configuration refresh query support');
     assert.ok(epmApiSource.includes('postJson(`${backendUrl}/api/epm/projects/configuration${refreshParam}`'), 'Expected configuration fetch endpoint');
     assert.ok(!epmApiSource.includes('/api/epm/projects/preview'), 'EPM settings must not call preview endpoint');
-    assert.ok(epmFetchSource.includes("export * from '../api/epmApi.js';"), 'Expected epmFetch.js compatibility re-export');
     assert.ok(epmViewDataSource.includes("if (epmTab === 'active' && !selectedSprint) {"), 'Expected Active EPM sprint guard in useEpmViewData.js');
     assert.ok(epmViewDataSource.includes('setEpmRollupTree(null);'), 'Expected Active EPM sprint guard to clear rollup tree');
     assert.ok(epmViewDataSource.includes('setEpmRollupLoading(false);'), 'Expected Active EPM sprint guard to stop rollup loading');

--- a/tests/test_epm_view_source_guards.js
+++ b/tests/test_epm_view_source_guards.js
@@ -6,7 +6,6 @@ const test = require('node:test');
 const dashboardPath = path.join(__dirname, '..', 'frontend', 'src', 'dashboard.jsx');
 const dashboardCssPath = path.join(__dirname, '..', 'frontend', 'src', 'styles', 'dashboard.css');
 const epmApiPath = path.join(__dirname, '..', 'frontend', 'src', 'api', 'epmApi.js');
-const epmFetchPath = path.join(__dirname, '..', 'frontend', 'src', 'epm', 'epmFetch.js');
 const epmViewDataPath = path.join(__dirname, '..', 'frontend', 'src', 'epm', 'useEpmViewData.js');
 const epmControlsPath = path.join(__dirname, '..', 'frontend', 'src', 'epm', 'EpmControls.jsx');
 const epmViewPath = path.join(__dirname, '..', 'frontend', 'src', 'epm', 'EpmView.jsx');
@@ -33,7 +32,6 @@ const emptyStateSource = fs.existsSync(emptyStatePath) ? fs.readFileSync(emptySt
 const statusPillSource = fs.existsSync(statusPillPath) ? fs.readFileSync(statusPillPath, 'utf8') : '';
 const dashboardCssSource = fs.existsSync(dashboardCssPath) ? fs.readFileSync(dashboardCssPath, 'utf8') : '';
 const epmApiSource = fs.existsSync(epmApiPath) ? fs.readFileSync(epmApiPath, 'utf8') : '';
-const epmFetchSource = fs.readFileSync(epmFetchPath, 'utf8');
 const epmViewDataSource = fs.existsSync(epmViewDataPath) ? fs.readFileSync(epmViewDataPath, 'utf8') : '';
 const epmControlsSource = fs.existsSync(epmControlsPath) ? fs.readFileSync(epmControlsPath, 'utf8') : '';
 const epmViewSource = fs.existsSync(epmViewPath) ? fs.readFileSync(epmViewPath, 'utf8') : '';
@@ -346,7 +344,7 @@ test('EPM module homes own rollup fetch and rendering while staying isolated fro
     assert.ok(epmRollupTreeSource.includes('EpmEpicNode'), 'Expected reusable epic renderer in EpmRollupTree.jsx');
     assert.ok(epmRollupTreeSource.includes('EpmRollupIssue'), 'Expected reusable issue renderer in EpmRollupTree.jsx');
 
-    for (const source of [epmApiSource, epmFetchSource, epmViewSource, epmRollupPanelSource, epmRollupTreeSource]) {
+    for (const source of [epmApiSource, epmViewSource, epmRollupPanelSource, epmRollupTreeSource]) {
         assert.ok(!source.includes('/api/tasks-with-team-name'), 'EPM modules must not fetch ENG tasks');
         assert.ok(!source.includes('/api/backlog-epics'), 'EPM modules must not fetch ENG backlog epics');
         assert.ok(!source.includes('showPlanning'), 'EPM modules must not own planning state');

--- a/tests/test_frontend_api_source_guards.js
+++ b/tests/test_frontend_api_source_guards.js
@@ -174,20 +174,18 @@ test('shared API HTTP helpers preserve caller options and headers', async () => 
     }
 });
 
-test('EPM API module owns endpoint construction while epmFetch remains a compatibility re-export', () => {
+test('EPM API module owns endpoint construction without EPM compatibility wrappers', () => {
     const epmApiPath = path.join(frontendSrcPath, 'api', 'epmApi.js');
     const epmFetchPath = path.join(frontendSrcPath, 'epm', 'epmFetch.js');
     assert.ok(fs.existsSync(epmApiPath), 'Expected frontend/src/api/epmApi.js to exist');
+    assert.ok(!fs.existsSync(epmFetchPath), 'Did not expect frontend/src/epm/epmFetch.js compatibility wrapper');
 
     const epmApiSource = readSource(epmApiPath);
-    const epmFetchSource = readSource(epmFetchPath);
 
     assert.ok(epmApiSource.includes("from './http.js'"), 'Expected EPM API module to use shared HTTP helpers');
     assert.ok(epmApiSource.includes('/api/epm/projects/${encodeURIComponent(projectId)}/rollup?${params.toString()}'), 'Expected project rollup URL construction in epmApi.js');
     assert.ok(epmApiSource.includes('/api/epm/projects/rollup/all?${params.toString()}'), 'Expected aggregate rollup URL construction in epmApi.js');
     assert.ok(epmApiSource.includes("fetchEpmConfigurationProjects(backendUrl, draftConfig, options = {})"), 'Expected configuration project wrapper in epmApi.js');
-    assert.ok(epmFetchSource.includes("export * from '../api/epmApi.js';"), 'Expected epmFetch.js to re-export the EPM API module');
-    assert.ok(!/\/api\/epm(?:\/|\b)/.test(epmFetchSource), 'Did not expect EPM endpoint literals in compatibility wrapper');
 });
 
 test('ENG API module owns ENG task, backlog, and dependency endpoint construction', () => {


### PR DESCRIPTION
## Summary
- Remove root EPM compatibility modules now that callers import `backend.epm.*` directly.
- Remove the unused frontend EPM API re-export wrapper.
- Update source guards and docs so the removed compatibility layers do not return.

## Test Plan
- `PYTHONPATH=/tmp/jira-planner-pydeps JIRA_URL=https://jira.example.test JIRA_EMAIL=test@example.test JIRA_TOKEN=synthetic python3 -m unittest discover -s tests`
- `/Users/a.feygin/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin/node --test tests/*.js`
- `npm run build`
- `git diff --check`
