### PR TITLE
Fix LibreSSL urllib3 startup warning

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -260,6 +260,7 @@ When the user corrects your approach, append a one-line rule here before ending 
 - Keep local task changes in the checkout the user is actively viewing; use a secondary worktree only when the user explicitly asks for one.
 - For shared header/menu UI changes, add or update Playwright assertions for menu layering and icon/control geometry before reporting visual verification.
 - Before merging backend dependency or startup-path changes, launch `source .venv/bin/activate; python3 jira_server.py` and verify `/api/test`.
+- Treat Python dependency/runtime warnings before the Flask startup banner as failed server verification unless the warning is intentionally documented as benign.
 - In settings, keep Team Groups/Group Labels and ENG/EPM view preferences separate from admin-only shared configuration; never bundle their saves with scope, field, priority, issue-type, or EPM mapping writes.
 - For cross-layer access or configuration changes, verify the backend response contract and the frontend render/edit/save gates together; do not treat backend route tests as enough when UI permissions control the user journey.
 - Pre-DB OAuth treats every signed-in Atlassian user as a local tool admin; when environment JSON exists, settings should default to Team Groups/EPM workflows instead of setup tabs.

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ flask-cors==6.0.2
 requests==2.32.5
 python-dotenv==1.2.1
 openpyxl==3.1.5
-urllib3==2.6.3
+urllib3==1.26.20
 SQLAlchemy==2.0.44
 alembic==1.14.0
 psycopg[binary]==3.2.13

--- a/tests/test_env_config_docs.py
+++ b/tests/test_env_config_docs.py
@@ -21,6 +21,20 @@ FORBIDDEN_DB_OAUTH_EPM_ENV_NAMES = (
 
 
 class EnvConfigDocsTests(unittest.TestCase):
+    def test_requirements_pin_libressl_compatible_urllib3(self):
+        requirements = (REPO_ROOT / "requirements.txt").read_text(encoding="utf8").splitlines()
+        urllib3_pins = [
+            line.strip()
+            for line in requirements
+            if line.strip().lower().startswith("urllib3==")
+        ]
+
+        self.assertEqual(
+            urllib3_pins,
+            ["urllib3==1.26.20"],
+            "The local Python 3.9 venv is linked against LibreSSL; urllib3 v2 emits a startup warning.",
+        )
+
     def test_db_oauth_epm_docs_do_not_reference_basic_credential_env_names(self):
         offenders = []
         for path in DOC_PATHS:


### PR DESCRIPTION
## Summary
- Pin urllib3 to 1.26.20 for the local Python 3.9/LibreSSL runtime so Flask startup no longer emits urllib3 v2's NotOpenSSLWarning.
- Add a requirements guard test for the compatible pin.
- Add a project learning that Python dependency/runtime warnings before Flask startup count as failed verification unless intentionally documented.

## Verification
- source .venv/bin/activate; python3 -W error - <<'PY'
import ssl, urllib3, requests
print('openssl:', ssl.OPENSSL_VERSION)
print('urllib3:', urllib3.__version__)
print('requests:', requests.__version__)
PY
- source .venv/bin/activate; python3 -m unittest tests.test_env_config_docs
- source .venv/bin/activate; python3 -m unittest discover -s tests
- source .venv/bin/activate; python3 jira_server.py
- curl -fsS http://127.0.0.1:5050/api/test