### PR TITLE
docs: mark completed plan slices done

### DIFF
--- a/docs/plans/2026-05-01-codebase-structure-optimization.md
+++ b/docs/plans/2026-05-01-codebase-structure-optimization.md
@@ -1,6 +1,6 @@
 # Codebase Structure Optimization Support History
 
-> **Legacy plan status:** Support/history context. Do not execute from this file. Current executable codebase-operability slices are tracked in `EXEC-codebase-operability-*` plans.
+> **Legacy plan status:** Support/history context. Do not execute from this file. Recently completed codebase-operability slices are tracked in `DONE-codebase-operability-*` plans.
 
 Date: 2026-05-01
 Plan branch: `docs/codebase-structure-optimization-plan`

--- a/docs/plans/DONE-codebase-operability-capacity-service-extraction.md
+++ b/docs/plans/DONE-codebase-operability-capacity-service-extraction.md
@@ -1,6 +1,6 @@
 # Codebase Operability: Capacity Service Extraction
 
-> **Status:** Implemented and verified locally on 2026-05-28. Keep as `EXEC-*` until acceptance or merge.
+> **Status:** Done. Executed in PR #54 (`879ad59`). Kept for audit context only.
 
 ## Goal
 

--- a/docs/plans/DONE-codebase-operability-config-repository-selection.md
+++ b/docs/plans/DONE-codebase-operability-config-repository-selection.md
@@ -1,6 +1,6 @@
 # Codebase Operability: Config Repository Selection
 
-> **Status:** Implemented locally and verified on 2026-05-28. Keep as `EXEC-*` until acceptance or merge.
+> **Status:** Done. Executed in PR #54 (`879ad59`). Kept for audit context only.
 
 ## Goal
 

--- a/docs/plans/DONE-codebase-operability-css-split.md
+++ b/docs/plans/DONE-codebase-operability-css-split.md
@@ -1,6 +1,6 @@
 # Codebase Operability: CSS Source Split
 
-> **Status:** Implemented locally and verified on 2026-05-28. Keep as `EXEC-*` until acceptance or merge.
+> **Status:** Done. Executed in PR #54 (`879ad59`). Kept for audit context only.
 
 ## Goal
 

--- a/docs/plans/DONE-codebase-operability-dependency-focus-utils.md
+++ b/docs/plans/DONE-codebase-operability-dependency-focus-utils.md
@@ -1,6 +1,6 @@
 # Codebase Operability: Dependency Focus Utilities
 
-> **Status:** Implemented and verified locally on 2026-05-28. Keep as `EXEC-*` until acceptance or merge.
+> **Status:** Done. Executed in PR #54 (`879ad59`). Kept for audit context only.
 
 ## Goal
 

--- a/docs/plans/DONE-codebase-operability-doc-cleanup.md
+++ b/docs/plans/DONE-codebase-operability-doc-cleanup.md
@@ -1,6 +1,6 @@
 # Codebase Operability Documentation Cleanup Slice
 
-> **Status:** Implemented locally and verified on 2026-05-28. Keep as `EXEC-*` until acceptance or merge.
+> **Status:** Done. Executed in PR #54 (`879ad59`). Kept for audit context only.
 
 ## Goal
 

--- a/docs/plans/DONE-codebase-operability-eng-planning-capacity-aggregates.md
+++ b/docs/plans/DONE-codebase-operability-eng-planning-capacity-aggregates.md
@@ -1,6 +1,6 @@
 # Codebase Operability: ENG Planning Capacity Aggregates
 
-> **Status:** Implemented and verified locally on 2026-05-28. Keep as `EXEC-*` until acceptance or merge.
+> **Status:** Done. Executed in PR #54 (`879ad59`). Kept for audit context only.
 
 ## Goal
 

--- a/docs/plans/DONE-codebase-operability-eng-planning-capacity-utils.md
+++ b/docs/plans/DONE-codebase-operability-eng-planning-capacity-utils.md
@@ -1,6 +1,6 @@
 # Codebase Operability: ENG Planning Capacity Utils
 
-> **Status:** Implemented and verified locally on 2026-05-28. Keep as `EXEC-*` until acceptance or merge.
+> **Status:** Done. Executed in PR #54 (`879ad59`). Kept for audit context only.
 
 ## Goal
 

--- a/docs/plans/DONE-codebase-operability-eng-planning-selection-stats.md
+++ b/docs/plans/DONE-codebase-operability-eng-planning-selection-stats.md
@@ -1,6 +1,6 @@
 # Codebase Operability: ENG Planning Selection Stats
 
-> **Status:** Implemented and verified locally on 2026-05-28. Keep as `EXEC-*` until acceptance or merge.
+> **Status:** Done. Executed in PR #54 (`879ad59`). Kept for audit context only.
 
 ## Goal
 

--- a/docs/plans/DONE-codebase-operability-epm-aggregate-extraction.md
+++ b/docs/plans/DONE-codebase-operability-epm-aggregate-extraction.md
@@ -1,6 +1,6 @@
 # Codebase Operability EPM Aggregate Extraction Slice
 
-> **Status:** Implemented locally and verified on 2026-05-28. Keep as `EXEC-*` until acceptance or merge.
+> **Status:** Done. Executed in PR #54 (`879ad59`). Kept for audit context only.
 
 ## Goal
 

--- a/docs/plans/DONE-codebase-operability-epm-config-extraction.md
+++ b/docs/plans/DONE-codebase-operability-epm-config-extraction.md
@@ -1,6 +1,6 @@
 # Codebase Operability: EPM Config Extraction
 
-> **Status:** Implemented locally and verified on 2026-05-28. Keep as `EXEC-*` until acceptance or merge.
+> **Status:** Done. Executed in PR #54 (`879ad59`). Kept for audit context only.
 
 ## Goal
 

--- a/docs/plans/DONE-codebase-operability-epm-issues-extraction.md
+++ b/docs/plans/DONE-codebase-operability-epm-issues-extraction.md
@@ -1,6 +1,6 @@
 # Codebase Operability: EPM Issues Extraction
 
-> **Status:** Implemented locally and verified on 2026-05-28. Keep as `EXEC-*` until acceptance or merge.
+> **Status:** Done. Executed in PR #54 (`879ad59`). Kept for audit context only.
 
 ## Goal
 

--- a/docs/plans/DONE-codebase-operability-epm-payload-helpers.md
+++ b/docs/plans/DONE-codebase-operability-epm-payload-helpers.md
@@ -1,6 +1,6 @@
 # Codebase Operability: EPM Payload Helpers
 
-> **Status:** Implemented locally and verified on 2026-05-28. Keep as `EXEC-*` until acceptance or merge.
+> **Status:** Done. Executed in PR #54 (`879ad59`). Kept for audit context only.
 
 ## Goal
 

--- a/docs/plans/DONE-codebase-operability-frontend-api-boundary.md
+++ b/docs/plans/DONE-codebase-operability-frontend-api-boundary.md
@@ -1,6 +1,6 @@
 # Codebase Operability: Frontend API Boundary
 
-> **Status:** Implemented locally and verified on 2026-05-28. Keep as `EXEC-*` until acceptance or merge.
+> **Status:** Done. Executed in PR #54 (`879ad59`). Kept for audit context only.
 
 ## Goal
 

--- a/docs/plans/DONE-codebase-operability-group-config-service.md
+++ b/docs/plans/DONE-codebase-operability-group-config-service.md
@@ -1,6 +1,6 @@
 # Codebase Operability: Group Config Service
 
-> **Status:** In progress on 2026-05-28. Keep as `EXEC-*` until acceptance or merge.
+> **Status:** Done. Executed in PR #54 (`879ad59`). Kept for audit context only.
 
 ## Goal
 

--- a/docs/plans/DONE-codebase-operability-import-safe-startup.md
+++ b/docs/plans/DONE-codebase-operability-import-safe-startup.md
@@ -1,6 +1,6 @@
 # Codebase Operability Import-Safe Startup Slice
 
-> **Status:** Implemented locally and verified on 2026-05-28. Keep as `EXEC-*` until acceptance or merge.
+> **Status:** Done. Executed in PR #54 (`879ad59`). Kept for audit context only.
 
 ## Goal
 

--- a/docs/plans/DONE-codebase-operability-jira-issue-fetch-helpers.md
+++ b/docs/plans/DONE-codebase-operability-jira-issue-fetch-helpers.md
@@ -1,6 +1,6 @@
 # Codebase Operability: Jira Issue Fetch Helpers
 
-> **Status:** Implemented and verified locally on 2026-05-28. Keep as `EXEC-*` until acceptance or merge.
+> **Status:** Done. Executed in PR #54 (`879ad59`). Kept for audit context only.
 
 ## Goal
 

--- a/docs/plans/DONE-codebase-operability-local-oauth-store-extraction.md
+++ b/docs/plans/DONE-codebase-operability-local-oauth-store-extraction.md
@@ -1,6 +1,6 @@
 # Codebase Operability: Local OAuth Store Extraction
 
-> **Status:** Implemented locally and verified on 2026-05-28. Keep as `EXEC-*` until acceptance or merge.
+> **Status:** Done. Executed in PR #54 (`879ad59`). Kept for audit context only.
 
 ## Goal
 

--- a/docs/plans/DONE-codebase-operability-packaging-contract.md
+++ b/docs/plans/DONE-codebase-operability-packaging-contract.md
@@ -1,6 +1,6 @@
 # Codebase Operability Packaging Contract Slice
 
-> **Status:** Implemented locally and verified on 2026-05-28. Keep as `EXEC-*` until acceptance or merge.
+> **Status:** Done. Executed in PR #54 (`879ad59`). Kept for audit context only.
 
 ## Goal
 

--- a/docs/plans/DONE-codebase-operability-planning-action-bar.md
+++ b/docs/plans/DONE-codebase-operability-planning-action-bar.md
@@ -1,6 +1,6 @@
 # Codebase Operability: Planning Action Bar
 
-> **Status:** Implemented and verified locally on 2026-05-28. Keep as `EXEC-*` until acceptance or merge.
+> **Status:** Done. Executed in PR #54 (`879ad59`). Kept for audit context only.
 
 ## Goal
 

--- a/docs/plans/DONE-codebase-operability-planning-capacity-bar.md
+++ b/docs/plans/DONE-codebase-operability-planning-capacity-bar.md
@@ -1,6 +1,6 @@
 # Codebase Operability: Planning Capacity Bar Component
 
-> **Status:** In progress on 2026-05-28. Keep as `EXEC-*` until acceptance or merge.
+> **Status:** Done. Executed in PR #54 (`879ad59`). Kept for audit context only.
 
 ## Goal
 

--- a/docs/plans/DONE-codebase-operability-planning-project-split-bar.md
+++ b/docs/plans/DONE-codebase-operability-planning-project-split-bar.md
@@ -1,6 +1,6 @@
 # Codebase Operability: Planning Project Split Bar Component
 
-> **Status:** In progress on 2026-05-28. Keep as `EXEC-*` until acceptance or merge.
+> **Status:** Done. Executed in PR #54 (`879ad59`). Kept for audit context only.
 
 ## Goal
 

--- a/docs/plans/DONE-codebase-operability-priority-weights-service.md
+++ b/docs/plans/DONE-codebase-operability-priority-weights-service.md
@@ -1,6 +1,6 @@
 # Codebase Operability: Priority Weights Service
 
-> **Status:** In progress on 2026-05-28. Keep as `EXEC-*` until acceptance or merge.
+> **Status:** Done. Executed in PR #54 (`879ad59`). Kept for audit context only.
 
 ## Goal
 

--- a/docs/plans/DONE-codebase-operability-request-context-guardrails.md
+++ b/docs/plans/DONE-codebase-operability-request-context-guardrails.md
@@ -1,6 +1,6 @@
 # Codebase Operability Request-Context Guardrails Slice
 
-> **Status:** Implemented locally and verified on 2026-05-28. Keep as `EXEC-*` until acceptance or merge.
+> **Status:** Done. Executed in PR #54 (`879ad59`). Kept for audit context only.
 
 ## Goal
 

--- a/docs/plans/DONE-codebase-operability-sprint-service-extraction.md
+++ b/docs/plans/DONE-codebase-operability-sprint-service-extraction.md
@@ -1,6 +1,6 @@
 # Codebase Operability: Sprint Service Extraction
 
-> **Status:** Implemented and verified locally on 2026-05-28. Keep as `EXEC-*` until acceptance or merge.
+> **Status:** Done. Executed in PR #54 (`879ad59`). Kept for audit context only.
 
 ## Goal
 

--- a/docs/plans/DONE-codebase-operability-startup-preflight.md
+++ b/docs/plans/DONE-codebase-operability-startup-preflight.md
@@ -1,6 +1,6 @@
 # Codebase Operability Startup Preflight Slice
 
-> **Status:** Implemented locally and verified on 2026-05-28. Keep as `EXEC-*` until acceptance or merge.
+> **Status:** Done. Executed in PR #54 (`879ad59`). Kept for audit context only.
 
 ## Goal
 

--- a/docs/plans/DONE-codebase-operability-stats-cache-service.md
+++ b/docs/plans/DONE-codebase-operability-stats-cache-service.md
@@ -1,6 +1,6 @@
 # Codebase Operability: Stats Cache Service
 
-> **Status:** In progress on 2026-05-28. Keep as `EXEC-*` until acceptance or merge.
+> **Status:** Done. Executed in PR #54 (`879ad59`). Kept for audit context only.
 
 ## Goal
 

--- a/docs/plans/DONE-codebase-operability-structural-budgets.md
+++ b/docs/plans/DONE-codebase-operability-structural-budgets.md
@@ -1,6 +1,6 @@
 # Codebase Operability: Structural Budgets
 
-> **Status:** Implemented locally and verified on 2026-05-28. Keep as `EXEC-*` until acceptance or merge.
+> **Status:** Done. Executed in PR #54 (`879ad59`). Kept for audit context only.
 
 ## Goal
 

--- a/docs/plans/DONE-codebase-operability-team-catalog-service.md
+++ b/docs/plans/DONE-codebase-operability-team-catalog-service.md
@@ -1,6 +1,6 @@
 # Codebase Operability: Team Catalog Service
 
-> **Status:** In progress on 2026-05-28. Keep as `EXEC-*` until acceptance or merge.
+> **Status:** Done. Executed in PR #54 (`879ad59`). Kept for audit context only.
 
 ## Goal
 

--- a/docs/plans/DONE-codebase-operability-update-check-service.md
+++ b/docs/plans/DONE-codebase-operability-update-check-service.md
@@ -1,6 +1,6 @@
 # Codebase Operability: Update Check Service
 
-> **Status:** In progress on 2026-05-28. Keep as `EXEC-*` until acceptance or merge.
+> **Status:** Done. Executed in PR #54 (`879ad59`). Kept for audit context only.
 
 ## Goal
 

--- a/docs/plans/DONE-codebase-operability-verification.md
+++ b/docs/plans/DONE-codebase-operability-verification.md
@@ -1,6 +1,6 @@
 # Codebase Operability Verification Slice
 
-> **Status:** Implemented locally and verified on 2026-05-28. Keep as `EXEC-*` until acceptance or merge.
+> **Status:** Done. Executed in PR #54 (`879ad59`). Kept for audit context only.
 
 ## Goal
 

--- a/docs/plans/DONE-epm-project-reading-experience.md
+++ b/docs/plans/DONE-epm-project-reading-experience.md
@@ -1,5 +1,7 @@
 # EPM Project Reading Experience Implementation Plan
 
+> **Status:** Done. Executed in PR #41 (`94b759b`). Kept for audit context only.
+
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]` / `- [x]`) syntax for tracking.
 
 **Goal:** Make the EPM all-projects board answer which projects are on track, stale, or missing status updates without changing Jira/Home API behavior.

--- a/docs/plans/FUTURE-codebase-operability-improvements.md
+++ b/docs/plans/FUTURE-codebase-operability-improvements.md
@@ -55,36 +55,36 @@ No P0 issues were found. The main structural risk is that extracted modules exis
 
 ## Implementation Notes
 
-- The verification-command slice is implemented locally in `EXEC-codebase-operability-verification.md`.
-- The startup/preflight and storage-alias slice is implemented locally in `EXEC-codebase-operability-startup-preflight.md`.
-- The quickstart, May 1 plan reclassification, and current structure docs slice is implemented locally in `EXEC-codebase-operability-doc-cleanup.md`.
-- The release-zip packaging-contract slice is implemented locally in `EXEC-codebase-operability-packaging-contract.md`.
-- The import-safe startup/app-creation slice is implemented locally in `EXEC-codebase-operability-import-safe-startup.md`.
-- The worker fan-out request-context guardrail slice is implemented locally in `EXEC-codebase-operability-request-context-guardrails.md`.
-- The EPM aggregate rollup extraction slice is implemented locally in `EXEC-codebase-operability-epm-aggregate-extraction.md`.
-- The frontend API boundary slice is implemented locally in `EXEC-codebase-operability-frontend-api-boundary.md`.
-- The config repository selection slice is implemented locally in `EXEC-codebase-operability-config-repository-selection.md`.
-- The EPM config normalization extraction slice is implemented locally in `EXEC-codebase-operability-epm-config-extraction.md`.
-- The structural budgets slice is implemented locally and ratcheted after follow-up extractions in `EXEC-codebase-operability-structural-budgets.md`.
-- The EPM project issues extraction slice is implemented locally in `EXEC-codebase-operability-epm-issues-extraction.md`.
-- The local OAuth token-store extraction slice is implemented locally in `EXEC-codebase-operability-local-oauth-store-extraction.md`.
-- The CSS source split slice is implemented locally in `EXEC-codebase-operability-css-split.md`.
-- The EPM payload-helper extraction slice is implemented locally in `EXEC-codebase-operability-epm-payload-helpers.md`.
-- The ENG planning capacity utility extraction slice is implemented locally in `EXEC-codebase-operability-eng-planning-capacity-utils.md`.
-- The Jira issue fetch helper extraction slice is implemented locally in `EXEC-codebase-operability-jira-issue-fetch-helpers.md`.
-- The ENG planning selection-stats extraction slice is implemented locally in `EXEC-codebase-operability-eng-planning-selection-stats.md`.
-- The ENG planning capacity-aggregate extraction slice is implemented locally in `EXEC-codebase-operability-eng-planning-capacity-aggregates.md`.
-- The capacity service extraction slice is implemented locally in `EXEC-codebase-operability-capacity-service-extraction.md`.
-- The dependency-focus utility extraction slice is implemented locally in `EXEC-codebase-operability-dependency-focus-utils.md`.
-- The sprint service extraction slice is implemented locally in `EXEC-codebase-operability-sprint-service-extraction.md`.
-- The Planning action bar extraction slice is implemented locally in `EXEC-codebase-operability-planning-action-bar.md`.
-- The stats cache service extraction slice is implemented locally in `EXEC-codebase-operability-stats-cache-service.md`.
-- The Planning capacity bar extraction slice is implemented locally in `EXEC-codebase-operability-planning-capacity-bar.md`.
-- The update-check service extraction slice is implemented locally in `EXEC-codebase-operability-update-check-service.md`.
-- The Planning project split bar extraction slice is implemented locally in `EXEC-codebase-operability-planning-project-split-bar.md`.
-- The priority-weights service extraction slice is implemented locally in `EXEC-codebase-operability-priority-weights-service.md`.
-- The team-catalog service extraction slice is implemented locally in `EXEC-codebase-operability-team-catalog-service.md`.
-- The group-config service extraction slice is implemented locally in `EXEC-codebase-operability-group-config-service.md`.
+- The verification-command slice was completed in PR #54 (`879ad59`) in `DONE-codebase-operability-verification.md`.
+- The startup/preflight and storage-alias slice was completed in PR #54 (`879ad59`) in `DONE-codebase-operability-startup-preflight.md`.
+- The quickstart, May 1 plan reclassification, and current structure docs slice was completed in PR #54 (`879ad59`) in `DONE-codebase-operability-doc-cleanup.md`.
+- The release-zip packaging-contract slice was completed in PR #54 (`879ad59`) in `DONE-codebase-operability-packaging-contract.md`.
+- The import-safe startup/app-creation slice was completed in PR #54 (`879ad59`) in `DONE-codebase-operability-import-safe-startup.md`.
+- The worker fan-out request-context guardrail slice was completed in PR #54 (`879ad59`) in `DONE-codebase-operability-request-context-guardrails.md`.
+- The EPM aggregate rollup extraction slice was completed in PR #54 (`879ad59`) in `DONE-codebase-operability-epm-aggregate-extraction.md`.
+- The frontend API boundary slice was completed in PR #54 (`879ad59`) in `DONE-codebase-operability-frontend-api-boundary.md`.
+- The config repository selection slice was completed in PR #54 (`879ad59`) in `DONE-codebase-operability-config-repository-selection.md`.
+- The EPM config normalization extraction slice was completed in PR #54 (`879ad59`) in `DONE-codebase-operability-epm-config-extraction.md`.
+- The structural budgets slice was completed and ratcheted in PR #54 (`879ad59`) after follow-up extractions in `DONE-codebase-operability-structural-budgets.md`.
+- The EPM project issues extraction slice was completed in PR #54 (`879ad59`) in `DONE-codebase-operability-epm-issues-extraction.md`.
+- The local OAuth token-store extraction slice was completed in PR #54 (`879ad59`) in `DONE-codebase-operability-local-oauth-store-extraction.md`.
+- The CSS source split slice was completed in PR #54 (`879ad59`) in `DONE-codebase-operability-css-split.md`.
+- The EPM payload-helper extraction slice was completed in PR #54 (`879ad59`) in `DONE-codebase-operability-epm-payload-helpers.md`.
+- The ENG planning capacity utility extraction slice was completed in PR #54 (`879ad59`) in `DONE-codebase-operability-eng-planning-capacity-utils.md`.
+- The Jira issue fetch helper extraction slice was completed in PR #54 (`879ad59`) in `DONE-codebase-operability-jira-issue-fetch-helpers.md`.
+- The ENG planning selection-stats extraction slice was completed in PR #54 (`879ad59`) in `DONE-codebase-operability-eng-planning-selection-stats.md`.
+- The ENG planning capacity-aggregate extraction slice was completed in PR #54 (`879ad59`) in `DONE-codebase-operability-eng-planning-capacity-aggregates.md`.
+- The capacity service extraction slice was completed in PR #54 (`879ad59`) in `DONE-codebase-operability-capacity-service-extraction.md`.
+- The dependency-focus utility extraction slice was completed in PR #54 (`879ad59`) in `DONE-codebase-operability-dependency-focus-utils.md`.
+- The sprint service extraction slice was completed in PR #54 (`879ad59`) in `DONE-codebase-operability-sprint-service-extraction.md`.
+- The Planning action bar extraction slice was completed in PR #54 (`879ad59`) in `DONE-codebase-operability-planning-action-bar.md`.
+- The stats cache service extraction slice was completed in PR #54 (`879ad59`) in `DONE-codebase-operability-stats-cache-service.md`.
+- The Planning capacity bar extraction slice was completed in PR #54 (`879ad59`) in `DONE-codebase-operability-planning-capacity-bar.md`.
+- The update-check service extraction slice was completed in PR #54 (`879ad59`) in `DONE-codebase-operability-update-check-service.md`.
+- The Planning project split bar extraction slice was completed in PR #54 (`879ad59`) in `DONE-codebase-operability-planning-project-split-bar.md`.
+- The priority-weights service extraction slice was completed in PR #54 (`879ad59`) in `DONE-codebase-operability-priority-weights-service.md`.
+- The team-catalog service extraction slice was completed in PR #54 (`879ad59`) in `DONE-codebase-operability-team-catalog-service.md`.
+- The group-config service extraction slice was completed in PR #54 (`879ad59`) in `DONE-codebase-operability-group-config-service.md`.
 - Keep this as future scope until the user explicitly chooses a slice to execute.
 - Convert a chosen slice into a separate `EXEC-*` plan before implementation.
 - Do not execute multiple slices that touch `frontend/src/dashboard.jsx` in parallel.
@@ -93,11 +93,11 @@ No P0 issues were found. The main structural risk is that extracted modules exis
 - For UI-affecting slices, include Playwright assertions and screenshots.
 - For auth, DB, Home/Townsquare, EPM, or plan execution work, follow the `docs/plans/AGENTS.md` gate sweep rules before execution.
 
-## First Executable Slice Recommendation
+## First Completed Slice Record
 
-> **Slice status:** Converted to `EXEC-codebase-operability-verification.md` and implemented locally on 2026-05-28; keep the execution plan as `EXEC-*` until acceptance or merge.
+> **Slice status:** Converted to `DONE-codebase-operability-verification.md` and completed in PR #54 (`879ad59`) after local verification on 2026-05-28.
 
-Start with a small operability slice:
+The first completed operability slice:
 
 1. Add `npm run test:frontend:unit` for `node --test tests/test_*.js`.
 2. Add `npm run test:frontend:ui` for Playwright UI specs.

--- a/docs/plans/GATE-05-home-write-capability.md
+++ b/docs/plans/GATE-05-home-write-capability.md
@@ -1,6 +1,6 @@
 # GATE-05: Home Project Write Capability
 
-> **Gate status:** Blocked. Checked on 2026-05-28. Waiting for Jira Home/Townsquare API support or confirmed local capability for the project-update mutation.
+> **Gate status:** Blocked. Checked on 2026-05-29. Waiting for Jira Home/Townsquare API support or confirmed local capability for the project-update mutation.
 
 ## Purpose
 
@@ -15,7 +15,7 @@ Do not implement Home write routes, write buttons, retry UI, or write-route OAut
 | Field | Value |
 | --- | --- |
 | Status | Blocked |
-| Checked on | 2026-05-28 |
+| Checked on | 2026-05-29 |
 | Last result | FAIL insufficient_home_write_probe_input |
 | Blocker | Jira Home/Townsquare project update API capability is not confirmed locally |
 | Dependent work | Home project update route and UI from the deferred DONE-02 write scope |
@@ -127,6 +127,7 @@ Required tests after the gate passes:
 
 ## Last Check Notes
 
+- 2026-05-29: Startup sweep reviewed the gate while refreshing recently implemented plan statuses. `HOME_WRITE_PROBE_EMAIL`, `HOME_WRITE_PROBE_API_TOKEN`, `HOME_WRITE_PROBE_PROJECT_ID`, and `HOME_WRITE_PROBE_TEXT` are not present in the local environment, and this docs-only status cleanup adds no Home write route or mutation UI. No real Home write probe pass is recorded in the repo. Keep blocked with `FAIL insufficient_home_write_probe_input`.
 - 2026-05-28: Startup sweep ran the documented write probe without execute credentials while executing the codebase operability verification slice; result was `FAIL insufficient_home_write_probe_input`. This slice adds no Home write route, mutation UI, auth behavior, DB behavior, Home metadata behavior, or EPM route behavior. No real Home write probe pass is recorded in the repo. Keep blocked.
 - 2026-05-28: Startup sweep reviewed the gate while implementing a read-only EPM project progress bar. `HOME_WRITE_PROBE_EMAIL`, `HOME_WRITE_PROBE_API_TOKEN`, `HOME_WRITE_PROBE_PROJECT_ID`, and `HOME_WRITE_PROBE_TEXT` are not present in the local environment, and this UI change adds no Home write route or mutation UI. No real Home write probe pass is recorded in the repo. Keep blocked with `FAIL insufficient_home_write_probe_input`.
 - 2026-05-27: Startup sweep reviewed the gate while updating the GA4/EPM analytics plan. `HOME_WRITE_PROBE_EMAIL`, `HOME_WRITE_PROBE_API_TOKEN`, `HOME_WRITE_PROBE_PROJECT_ID`, and `HOME_WRITE_PROBE_TEXT` are not present in the local environment, and this plan update adds no Home write route or mutation UI. No real Home write probe pass is recorded in the repo. Keep blocked with `FAIL insufficient_home_write_probe_input`.

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -72,14 +72,18 @@ Use this file to choose the right plan before starting auth, DB, or Home/Townsqu
    - Supersedes the stale root-level `statistics_module_extraction_plan.md` from `origin/plan/statistics-module-extraction`.
    - Output: remaining legacy Statistics Teams, Priority, and Burndown utilities/components extracted from `frontend/src/dashboard.jsx` into the existing `frontend/src/stats/` package, with source guards, focused Node tests, full unit verification, Playwright smoke coverage, regenerated frontend dist output, and shared bounded hover positioning for stats chart readouts.
 
-## Future Codebase Structure And Operability
+2. `DONE-epm-project-reading-experience.md`
+   - Completed EPM project reading experience plan in PR #41 (`94b759b`). Use for audit and prerequisite evidence; do not execute as active work.
+   - Output: Home update freshness classification, stale/missing/unknown badges, stale date styling, visual fixture coverage, and freshness source guards for the EPM project board.
 
-1. `EXEC-codebase-operability-verification.md`
-   - Implemented locally and verified on 2026-05-28; keep as `EXEC-*` until acceptance or merge.
+## Codebase Structure And Operability
+
+1. `DONE-codebase-operability-verification.md`
+   - Completed in PR #54 (`879ad59`) after local verification on 2026-05-28. Use for audit only; do not execute as active work.
    - Expected output: local frontend unit/UI npm scripts, `make verify` for build/Python/security/Node/dist checks, and refreshed test-command documentation.
 
-2. `EXEC-codebase-operability-startup-preflight.md`
-   - Implemented locally and verified on 2026-05-28; keep as `EXEC-*` until acceptance or merge.
+2. `DONE-codebase-operability-startup-preflight.md`
+   - Completed in PR #54 (`879ad59`) after local verification on 2026-05-28. Use for audit only; do not execute as active work.
    - Expected output: operator preflight for runtime/auth/DB/encryption/migrations plus unified DB storage aliases.
 
 3. `FUTURE-codebase-operability-improvements.md`
@@ -89,116 +93,116 @@ Use this file to choose the right plan before starting auth, DB, or Home/Townsqu
 4. `2026-05-01-codebase-structure-optimization.md`
    - Support/history context for earlier structure extraction work. Do not execute directly.
 
-5. `EXEC-codebase-operability-doc-cleanup.md`
-   - Implemented locally and verified on 2026-05-28; keep as `EXEC-*` until acceptance or merge.
+5. `DONE-codebase-operability-doc-cleanup.md`
+   - Completed in PR #54 (`879ad59`) after local verification on 2026-05-28. Use for audit only; do not execute as active work.
    - Expected output: refreshed quickstart/setup docs, May 1 plan support/history status, and current README structure snapshot.
 
-6. `EXEC-codebase-operability-packaging-contract.md`
-   - Implemented locally and verified on 2026-05-28; keep as `EXEC-*` until acceptance or merge.
+6. `DONE-codebase-operability-packaging-contract.md`
+   - Completed in PR #54 (`879ad59`) after local verification on 2026-05-28. Use for audit only; do not execute as active work.
    - Expected output: explicit release-zip runnable-package contract and tests guarding the release zip shape.
 
-7. `EXEC-codebase-operability-import-safe-startup.md`
-   - Implemented locally and verified on 2026-05-28; keep as `EXEC-*` until acceptance or merge.
+7. `DONE-codebase-operability-import-safe-startup.md`
+   - Completed in PR #54 (`879ad59`) after local verification on 2026-05-28. Use for audit only; do not execute as active work.
    - Expected output: import-safe `jira_server`, explicit Flask app creation, and launch-path startup validation.
 
-8. `EXEC-codebase-operability-request-context-guardrails.md`
-   - Implemented locally and verified on 2026-05-28; keep as `EXEC-*` until acceptance or merge.
+8. `DONE-codebase-operability-request-context-guardrails.md`
+   - Completed in PR #54 (`879ad59`) after local verification on 2026-05-28. Use for audit only; do not execute as active work.
    - Expected output: tests guarding explicit request auth context propagation through worker fan-out.
 
-9. `EXEC-codebase-operability-epm-aggregate-extraction.md`
-   - Implemented locally and verified on 2026-05-28; keep as `EXEC-*` until acceptance or merge.
+9. `DONE-codebase-operability-epm-aggregate-extraction.md`
+   - Completed in PR #54 (`879ad59`) after local verification on 2026-05-28. Use for audit only; do not execute as active work.
    - Expected output: all-project EPM rollup orchestration moved to `backend/epm/aggregate.py` with `jira_server.py` shims preserved.
 
-10. `EXEC-codebase-operability-frontend-api-boundary.md`
-   - Implemented locally and verified on 2026-05-28; keep as `EXEC-*` until acceptance or merge.
+10. `DONE-codebase-operability-frontend-api-boundary.md`
+   - Completed in PR #54 (`879ad59`) after local verification on 2026-05-28. Use for audit only; do not execute as active work.
    - Expected output: remaining Scenario, stats, issue lookup, and EPM config endpoint construction moved out of `frontend/src/dashboard.jsx` into `frontend/src/api/*` modules.
 
-11. `EXEC-codebase-operability-config-repository-selection.md`
-   - Implemented locally and verified on 2026-05-28; keep as `EXEC-*` until acceptance or merge.
+11. `DONE-codebase-operability-config-repository-selection.md`
+   - Completed in PR #54 (`879ad59`) after local verification on 2026-05-28. Use for audit only; do not execute as active work.
    - Expected output: dashboard config load/save wrappers require explicit JSON selection when DB mode is active without request context.
 
-12. `EXEC-codebase-operability-epm-config-extraction.md`
-   - Implemented locally and verified on 2026-05-28; keep as `EXEC-*` until acceptance or merge.
+12. `DONE-codebase-operability-epm-config-extraction.md`
+   - Completed in PR #54 (`879ad59`) after local verification on 2026-05-28. Use for audit only; do not execute as active work.
    - Expected output: EPM config defaults and normalization helpers move into `backend/epm/config.py` with `jira_server.py` compatibility aliases preserved.
 
-13. `EXEC-codebase-operability-structural-budgets.md`
-   - Implemented locally and verified on 2026-05-28; keep as `EXEC-*` until acceptance or merge.
+13. `DONE-codebase-operability-structural-budgets.md`
+   - Completed in PR #54 (`879ad59`) after local verification on 2026-05-28. Use for audit only; do not execute as active work.
    - Expected output: source guard budgets prevent `jira_server.py` and `frontend/src/dashboard.jsx` from growing while extraction work continues, with ceilings ratcheted after follow-up extraction slices.
 
-14. `EXEC-codebase-operability-epm-issues-extraction.md`
-   - Implemented locally and verified on 2026-05-28; keep as `EXEC-*` until acceptance or merge.
+14. `DONE-codebase-operability-epm-issues-extraction.md`
+   - Completed in PR #54 (`879ad59`) after local verification on 2026-05-28. Use for audit only; do not execute as active work.
    - Expected output: EPM project issues endpoint orchestration moved to `backend/epm/issues.py` with the Flask route reduced to request parsing, dependency wiring, and JSON response handling.
 
-15. `EXEC-codebase-operability-local-oauth-store-extraction.md`
-   - Implemented locally and verified on 2026-05-28; keep as `EXEC-*` until acceptance or merge.
+15. `DONE-codebase-operability-local-oauth-store-extraction.md`
+   - Completed in PR #54 (`879ad59`) after local verification on 2026-05-28. Use for audit only; do not execute as active work.
    - Expected output: local OAuth token-store persistence, TTL cleanup, and refresh-lock mechanics moved to `backend/auth/local_oauth_store.py` with `jira_server.py` compatibility wrappers preserved.
 
-16. `EXEC-codebase-operability-css-split.md`
-   - Implemented locally and verified on 2026-05-28; keep as `EXEC-*` until acceptance or merge.
+16. `DONE-codebase-operability-css-split.md`
+   - Completed in PR #54 (`879ad59`) after local verification on 2026-05-28. Use for audit only; do not execute as active work.
    - Expected output: `frontend/src/styles/dashboard.css` becomes an ordered import entrypoint over feature-owned partials while esbuild still produces one bundled `frontend/dist/dashboard.css`.
 
-17. `EXEC-codebase-operability-epm-payload-helpers.md`
-   - Implemented locally and verified on 2026-05-28; keep as `EXEC-*` until acceptance or merge.
+17. `DONE-codebase-operability-epm-payload-helpers.md`
+   - Completed in PR #54 (`879ad59`) after local verification on 2026-05-28. Use for audit only; do not execute as active work.
    - Expected output: pure EPM issue payload helpers moved to `backend/epm/payload.py` with `jira_server.py` compatibility aliases preserved.
 
-18. `EXEC-codebase-operability-eng-planning-capacity-utils.md`
-   - Implemented locally and verified on 2026-05-28; keep as `EXEC-*` until acceptance or merge.
+18. `DONE-codebase-operability-eng-planning-capacity-utils.md`
+   - Completed in PR #54 (`879ad59`) after local verification on 2026-05-28. Use for audit only; do not execute as active work.
    - Expected output: pure ENG Planning capacity status, team metadata, total capacity, and project-capacity split helpers moved to `frontend/src/eng/planningCapacityUtils.js` while Planning state and rendering remain in `frontend/src/dashboard.jsx`.
 
-19. `EXEC-codebase-operability-jira-issue-fetch-helpers.md`
-   - Implemented locally and verified on 2026-05-28; keep as `EXEC-*` until acceptance or merge.
+19. `DONE-codebase-operability-jira-issue-fetch-helpers.md`
+   - Completed in PR #54 (`879ad59`) after local verification on 2026-05-28. Use for audit only; do not execute as active work.
    - Expected output: Jira issue key-batch and JQL pagination helpers moved to `backend/jira_client.py` with `jira_server.py` patchable wrappers preserved.
 
-20. `EXEC-codebase-operability-eng-planning-selection-stats.md`
-   - Implemented locally and verified on 2026-05-28; keep as `EXEC-*` until acceptance or merge.
+20. `DONE-codebase-operability-eng-planning-selection-stats.md`
+   - Completed in PR #54 (`879ad59`) after local verification on 2026-05-28. Use for audit only; do not execute as active work.
    - Expected output: pure selected Planning task filtering and selected story-point/team/project aggregation helpers moved to `frontend/src/eng/planningSelectionStats.js` while Planning state and rendering remain in `frontend/src/dashboard.jsx`.
 
-21. `EXEC-codebase-operability-eng-planning-capacity-aggregates.md`
-   - Implemented locally and verified on 2026-05-28; keep as `EXEC-*` until acceptance or merge.
+21. `DONE-codebase-operability-eng-planning-capacity-aggregates.md`
+   - Completed in PR #54 (`879ad59`) after local verification on 2026-05-28. Use for audit only; do not execute as active work.
    - Expected output: pure Planning capacity table aggregation and entry-shaping helpers moved to `frontend/src/eng/planningCapacityUtils.js` while capacity fetching, Planning state, and rendering remain in `frontend/src/dashboard.jsx`.
 
-22. `EXEC-codebase-operability-capacity-service-extraction.md`
-   - Implemented locally and verified on 2026-05-28; keep as `EXEC-*` until acceptance or merge.
+22. `DONE-codebase-operability-capacity-service-extraction.md`
+   - Completed in PR #54 (`879ad59`) after local verification on 2026-05-28. Use for audit only; do not execute as active work.
    - Expected output: Jira capacity JQL construction, capacity issue parsing, watcher fallback, and capacity route response handling moved out of `jira_server.py` into a backend service and route adapter while compatibility wrappers remain patchable.
 
-23. `EXEC-codebase-operability-dependency-focus-utils.md`
-   - Implemented locally and verified on 2026-05-28; keep as `EXEC-*` until acceptance or merge.
+23. `DONE-codebase-operability-dependency-focus-utils.md`
+   - Completed in PR #54 (`879ad59`) after local verification on 2026-05-28. Use for audit only; do not execute as active work.
    - Expected output: pure dependency focus/key helpers shared by `dashboard.jsx` and issue dependency rendering move into `frontend/src/issues/dependencyFocusUtils.js` while dependency chip UI and lookup fetching remain unchanged.
 
-24. `EXEC-codebase-operability-sprint-service-extraction.md`
-   - Implemented locally and verified on 2026-05-28; keep as `EXEC-*` until acceptance or merge.
+24. `DONE-codebase-operability-sprint-service-extraction.md`
+   - Completed in PR #54 (`879ad59`) after local verification on 2026-05-28. Use for audit only; do not execute as active work.
    - Expected output: sprint cache, board sprint loading, JQL fallback sprint discovery, and sprint de-duplication logic moved to `backend/services/sprints.py` while `jira_server.py` compatibility wrappers remain patchable.
 
-25. `EXEC-codebase-operability-planning-action-bar.md`
-   - Implemented locally and verified on 2026-05-28; keep as `EXEC-*` until acceptance or merge.
+25. `DONE-codebase-operability-planning-action-bar.md`
+   - Completed in PR #54 (`879ad59`) after local verification on 2026-05-28. Use for audit only; do not execute as active work.
    - Expected output: the ENG Planning action button row moved to `frontend/src/eng/PlanningActionBar.jsx` while Planning state, handlers, capacity math, and persistence stay in `dashboard.jsx`.
 
-26. `EXEC-codebase-operability-stats-cache-service.md`
-   - Implemented locally and verified on 2026-05-28; keep as `EXEC-*` until acceptance or merge.
+26. `DONE-codebase-operability-stats-cache-service.md`
+   - Completed in PR #54 (`879ad59`) after local verification on 2026-05-28. Use for audit only; do not execute as active work.
    - Expected output: completed-sprint stats file-cache load/save/invalidation and cache-key construction moved to `backend/services/stats_cache.py` while `jira_server.py` compatibility wrappers remain patchable.
 
-27. `EXEC-codebase-operability-planning-capacity-bar.md`
-   - Implemented locally and verified on 2026-05-28; keep as `EXEC-*` until acceptance or merge.
+27. `DONE-codebase-operability-planning-capacity-bar.md`
+   - Completed in PR #54 (`879ad59`) after local verification on 2026-05-28. Use for audit only; do not execute as active work.
    - Expected output: the ENG Planning capacity bar and selected-summary fallback moved to `frontend/src/eng/PlanningCapacityBar.jsx` while Planning state, capacity math inputs, team microbars, and project split bars stay in `dashboard.jsx`.
 
-28. `EXEC-codebase-operability-update-check-service.md`
-   - Implemented locally and verified on 2026-05-28; keep as `EXEC-*` until acceptance or merge.
+28. `DONE-codebase-operability-update-check-service.md`
+   - Completed in PR #54 (`879ad59`) after local verification on 2026-05-28. Use for audit only; do not execute as active work.
    - Expected output: `/api/version` git command, release-info fallback, and update payload construction moved to `backend/services/update_check.py` while `jira_server.py` compatibility wrappers remain patchable.
 
-29. `EXEC-codebase-operability-planning-project-split-bar.md`
-   - Implemented locally and verified on 2026-05-28; keep as `EXEC-*` until acceptance or merge.
+29. `DONE-codebase-operability-planning-project-split-bar.md`
+   - Completed in PR #54 (`879ad59`) after local verification on 2026-05-28. Use for audit only; do not execute as active work.
    - Expected output: the ENG Planning selected-SP-by-project bar moved to `frontend/src/eng/PlanningProjectSplitBar.jsx` while selected project stat derivation, excluded capacity math, and Planning state stay in `dashboard.jsx`.
 
-30. `EXEC-codebase-operability-priority-weights-service.md`
-   - Implemented locally and verified on 2026-05-28; keep as `EXEC-*` until acceptance or merge.
+30. `DONE-codebase-operability-priority-weights-service.md`
+   - Completed in PR #54 (`879ad59`) after local verification on 2026-05-28. Use for audit only; do not execute as active work.
    - Expected output: stats priority weight normalization, env parsing, and effective config selection moved to `backend/services/priority_weights.py` while `jira_server.py` compatibility wrappers remain patchable.
 
-31. `EXEC-codebase-operability-team-catalog-service.md`
-   - Implemented locally and verified on 2026-05-28; keep as `EXEC-*` until acceptance or merge.
+31. `DONE-codebase-operability-team-catalog-service.md`
+   - Completed in PR #54 (`879ad59`) after local verification on 2026-05-28. Use for audit only; do not execute as active work.
    - Expected output: team catalog, catalog metadata, and group team-label normalization moved to `backend/services/team_catalog.py` while `jira_server.py` compatibility wrappers remain patchable.
 
-32. `EXEC-codebase-operability-group-config-service.md`
-   - Implemented locally and verified on 2026-05-28; keep as `EXEC-*` until acceptance or merge.
+32. `DONE-codebase-operability-group-config-service.md`
+   - Completed in PR #54 (`879ad59`) after local verification on 2026-05-28. Use for audit only; do not execute as active work.
    - Expected output: team-group env parsing, validation, and default construction moved to `backend/services/group_config.py` while `jira_server.py` compatibility wrappers remain patchable.
 
 ## Legacy Unclassified Date-Only Plans


### PR DESCRIPTION
Archive merged codebase-operability and EPM reading plans as DONE, refresh the plan index, and record the latest Home write gate sweep.