### PR TITLE
Fix the GitLab CI pipeline runner/setup issue.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -22,20 +22,26 @@ cache:
     - .npm/
     - .cache/pip/
 
-verify:
+python_verify:
   image: python:3.11-bookworm
   stage: verify
+  tags:
+    - shared-amd64
   before_script:
-    - apt-get update
-    - apt-get install -y --no-install-recommends ca-certificates curl git
-    - curl -fsSL https://deb.nodesource.com/setup_20.x | bash -
-    - apt-get install -y --no-install-recommends nodejs
     - python -m pip install --upgrade pip
     - python -m pip install -r requirements.txt
     - python -m pip install -e .
-    - npm ci --cache .npm --prefer-offline
   script:
     - python -m unittest discover -s tests
+
+frontend_verify:
+  image: node:20-bookworm
+  stage: verify
+  tags:
+    - shared-amd64
+  before_script:
+    - npm ci --cache .npm --prefer-offline
+  script:
     - npm run build
     - npm run test:frontend:unit
     - git diff --exit-code frontend/dist
@@ -48,7 +54,8 @@ container_build:
   services:
     - docker:27-dind
   needs:
-    - verify
+    - python_verify
+    - frontend_verify
   variables:
     DOCKER_HOST: tcp://docker:2375
     DOCKER_TLS_CERTDIR: ""

--- a/tests/test_gitlab_ci_contract.py
+++ b/tests/test_gitlab_ci_contract.py
@@ -28,10 +28,11 @@ class GitLabCiContractTests(unittest.TestCase):
         ci = self._ci()
 
         for command in (
+            "python -m pip install --upgrade pip",
             "python -m pip install -r requirements.txt",
             "python -m pip install -e .",
             "python -m unittest discover -s tests",
-            "npm ci",
+            "npm ci --cache .npm --prefer-offline",
             "npm run build",
             "npm run test:frontend:unit",
             "git diff --exit-code frontend/dist",
@@ -44,6 +45,33 @@ class GitLabCiContractTests(unittest.TestCase):
             'APP_ENVIRONMENT_KEY: "local"',
         ):
             self.assertIn(env_setting, ci)
+
+    def test_gitlab_ci_splits_python_and_frontend_verification(self):
+        ci = self._ci()
+
+        self.assertRegex(ci, r"(?m)^python_verify:\n")
+        self.assertRegex(ci, r"(?m)^frontend_verify:\n")
+        self.assertRegex(ci, r"(?ms)^python_verify:.*?image: python:3\.11-bookworm")
+        self.assertRegex(ci, r"(?ms)^frontend_verify:.*?image: node:20-bookworm")
+        self.assertEqual(ci.count("shared-amd64"), 2)
+
+    def test_gitlab_ci_does_not_bootstrap_node_in_python_job(self):
+        ci = self._ci()
+
+        for forbidden in (
+            "deb.nodesource.com",
+            "setup_20.x",
+            "apt-get install -y --no-install-recommends nodejs",
+        ):
+            self.assertNotIn(forbidden, ci)
+
+    def test_container_build_needs_both_verify_jobs(self):
+        ci = self._ci()
+        container_build = ci.split("container_build:", 1)[1]
+
+        self.assertIn("needs:", container_build)
+        self.assertIn("- python_verify", container_build)
+        self.assertIn("- frontend_verify", container_build)
 
     def test_gitlab_ci_builds_sha_tagged_image_from_dockerfile(self):
         ci = self._ci()


### PR DESCRIPTION
Context:
- The current GitLab pipeline has a single `verify` job using `python:3.11-bookworm`.
- That job installs Node 20 at runtime via NodeSource:
  `curl -fsSL https://deb.nodesource.com/setup_20.x | bash -`
- This made CI fragile and then the split frontend job got stuck because project runners are tagged.
- Available online instance runner tag: `shared-amd64`.

Required changes:
1. In `.gitlab-ci.yml`, split the single `verify` job into:
   - `python_verify`
   - `frontend_verify`

2. `python_verify` should:
   - use `image: python:3.11-bookworm`
   - use runner tag `shared-amd64`
   - install Python deps:
     - `python -m pip install --upgrade pip`
     - `python -m pip install -r requirements.txt`
     - `python -m pip install -e .`
   - run:
     - `python -m unittest discover -s tests`

3. `frontend_verify` should:
   - use `image: node:20-bookworm`
   - use runner tag `shared-amd64`
   - run:
     - `npm ci --cache .npm --prefer-offline`
     - `npm run build`
     - `npm run test:frontend:unit`
     - `git diff --exit-code frontend/dist`

4. Remove all NodeSource/bootstrap setup from CI:
   - no `deb.nodesource.com`
   - no `setup_20.x`
   - no installing Node inside the Python image

5. Update `container_build.needs` to depend on both:
   - `python_verify`
   - `frontend_verify`

6. Update `tests/test_gitlab_ci_contract.py` so it enforces:
   - both verify jobs exist
   - expected Python and Node images are used
   - `shared-amd64` appears exactly twice
   - NodeSource strings are absent
   - `container_build` needs both verify jobs

Verification:
- Run `.venv/bin/python -m unittest tests.test_gitlab_ci_contract`
- Run `git diff --check`

Expected result:
- GitLab should schedule both verify jobs on the `shared-amd64` runner instead of leaving `frontend_verify` stuck with “no runners online assigned”.