### PR TITLE
Fix EPM active sprint story rollups

### DIFF
--- a/backend/epm/rollup.py
+++ b/backend/epm/rollup.py
@@ -166,7 +166,9 @@ def build_per_project_rollup(project_id, tab, sprint, deps):
             return deps.add_clause_to_jql(jql, f'Sprint = {sprint}')
         return jql
 
-    def filter_leaf_issues_for_tab(issues):
+    def filter_leaf_issues_for_tab(issues, sprint_filtered=False):
+        if sprint_filtered:
+            return issues
         if should_apply_epm_sprint(tab):
             return _filter_active_leaf_issues(issues, issue_type_sets, sprint, deps.normalize_epm_text)
         if tab == 'backlog':
@@ -199,11 +201,13 @@ def build_per_project_rollup(project_id, tab, sprint, deps):
             for issue in q1_issues
         )
         q2_jql = deps.add_clause_to_jql(base_jql, q2_predicate)
+        q2_sprint_filtered = False
         if not q2_has_initiative_seed:
             q2_jql = with_sprint_filter(q2_jql)
+            q2_sprint_filtered = should_apply_epm_sprint(tab)
         q2_raw = deps.fetch_epm_rollup_query(q2_jql, 'q2', headers, fields_list, truncated_queries)
         q2_issues, _ = deps.shape_epm_rollup_issue_payload(q2_raw, epic_link_field_id=epic_link_field_id, team_field_id=team_field_id)
-        q2_issues = filter_leaf_issues_for_tab(q2_issues)
+        q2_issues = filter_leaf_issues_for_tab(q2_issues, sprint_filtered=q2_sprint_filtered)
 
     q3_seed_keys = sorted({
         issue.get('key')
@@ -217,7 +221,7 @@ def build_per_project_rollup(project_id, tab, sprint, deps):
         q3_jql = with_sprint_filter(deps.add_clause_to_jql(base_jql, q3_predicate))
         q3_raw = deps.fetch_epm_rollup_query(q3_jql, 'q3', headers, fields_list, truncated_queries)
         q3_issues, _ = deps.shape_epm_rollup_issue_payload(q3_raw, epic_link_field_id=epic_link_field_id, team_field_id=team_field_id)
-        q3_issues = filter_leaf_issues_for_tab(q3_issues)
+        q3_issues = filter_leaf_issues_for_tab(q3_issues, sprint_filtered=should_apply_epm_sprint(tab))
 
     hierarchy = deps.build_epm_rollup_hierarchy(
         deps.dedupe_issues_by_key(q1_issues + q2_issues + q3_issues),

--- a/tests/test_epm_rollup_builder.py
+++ b/tests/test_epm_rollup_builder.py
@@ -129,6 +129,22 @@ class BuildPerProjectRollupTests(unittest.TestCase):
             'STORY-1',
         )
 
+    def test_active_rollup_keeps_story_from_sprint_filtered_child_query_without_sprint_field(self):
+        project = {'id': 'proj-sprint', 'label': 'synthetic_label_alpha', 'resolvedLinkage': {'labels': ['synthetic_label_alpha'], 'epicKeys': []}}
+        q1 = [self.make_issue('EPIC-1', 'Epic', labels=['synthetic_label_alpha'])]
+        q2 = [self.make_issue('STORY-1', 'Story', parent_key='EPIC-1', sprint='absent')]
+        deps, _, fetch_calls = self.make_deps(project, [q1, q2])
+
+        payload, status, _headers = build_per_project_rollup('proj-sprint', 'active', '42', deps)
+
+        self.assertEqual(status, 200)
+        self.assertEqual([name for name, _ in fetch_calls], ['q1', 'q2'])
+        self.assertIn('Sprint = 42', fetch_calls[1][1])
+        self.assertEqual(
+            [story['key'] for story in payload['rootEpics']['EPIC-1']['stories']],
+            ['STORY-1'],
+        )
+
     def test_backlog_prunes_sprinted_stories_and_done_or_in_progress_epics(self):
         project = {'id': 'proj-e', 'label': 'synthetic_label_alpha', 'resolvedLinkage': {'labels': ['synthetic_label_alpha'], 'epicKeys': []}}
         q1 = [


### PR DESCRIPTION
## Summary
- Trust Jira sprint-filtered child rollup query results when building active EPM project hierarchies.
- Preserve existing initiative-root active rollup filtering and backlog filtering behavior.
- Add regression coverage for stories returned by a sprint-filtered child query without a sprint field in the response payload.

## Validation
- `python -m unittest discover -s tests` passed: 883 tests, 1 skipped.
- `git diff --check` passed.
## Notes
- No frontend source changed, so no frontend build or screenshots were needed.