### PR TITLE
fix(jira): bound connect timeout so transient stalls retry within budget

### DIFF
--- a/backend/jira_client.py
+++ b/backend/jira_client.py
@@ -10,6 +10,11 @@ import requests
 
 RETRYABLE_JIRA_STATUS_CODES = {429, 500, 502, 503, 504}
 
+# Bound how long a single attempt may spend establishing the TCP/TLS connection.
+# Connection-level stalls (the dominant transient Jira failure) must fail fast so
+# the retry budget is spent on actual retries instead of one long hang.
+DEFAULT_CONNECT_TIMEOUT_SECONDS = 5.0
+
 
 def _noop_log(*_parts):
     return None
@@ -98,7 +103,8 @@ def _build_jira_unavailable_response(message, attempts=0, elapsed_seconds=0.0, u
     return response_cls(503, payload)
 
 
-def resilient_jira_get(url, *, params=None, headers=None, timeout=30, session=None, breaker=None,
+def resilient_jira_get(url, *, params=None, headers=None, timeout=30, connect_timeout=None,
+                       session=None, breaker=None,
                        now_fn=None, sleep_fn=None, rand_fn=None,
                        max_attempts=None, max_elapsed_seconds=None,
                        base_delay_seconds=None, max_delay_seconds=None,
@@ -122,6 +128,10 @@ def resilient_jira_get(url, *, params=None, headers=None, timeout=30, session=No
     max_elapsed_seconds = float(max_elapsed_seconds if max_elapsed_seconds is not None else 10)
     base_delay_seconds = float(base_delay_seconds if base_delay_seconds is not None else 0.5)
     max_delay_seconds = float(max_delay_seconds if max_delay_seconds is not None else 3)
+    connect_timeout = float(connect_timeout if connect_timeout is not None else DEFAULT_CONNECT_TIMEOUT_SECONDS)
+    # Short connect timeout, full read timeout: connection stalls fail fast and retry;
+    # legitimately slow queries keep the caller's read budget.
+    request_timeout = (min(connect_timeout, timeout), timeout)
 
     started_at = now_fn()
     allowed, breaker_state = breaker.before_request(started_at)
@@ -143,7 +153,7 @@ def resilient_jira_get(url, *, params=None, headers=None, timeout=30, session=No
         attempts += 1
         attempt_started = now_fn()
         try:
-            response = session.get(url, params=params, headers=headers, timeout=timeout)
+            response = session.get(url, params=params, headers=headers, timeout=request_timeout)
             latency_ms = round((now_fn() - attempt_started) * 1000, 1)
             last_status = getattr(response, 'status_code', None)
             if last_status not in retryable_status_codes:

--- a/jira_server.py
+++ b/jira_server.py
@@ -166,6 +166,7 @@ JIRA_RETRY_MAX_ATTEMPTS = int(os.getenv('JIRA_RETRY_MAX_ATTEMPTS', '4'))
 JIRA_RETRY_MAX_ELAPSED_SECONDS = float(os.getenv('JIRA_RETRY_MAX_ELAPSED_SECONDS', '10'))
 JIRA_RETRY_BASE_DELAY_SECONDS = float(os.getenv('JIRA_RETRY_BASE_DELAY_SECONDS', '0.5'))
 JIRA_RETRY_MAX_DELAY_SECONDS = float(os.getenv('JIRA_RETRY_MAX_DELAY_SECONDS', '3'))
+JIRA_HTTP_CONNECT_TIMEOUT_SECONDS = float(os.getenv('JIRA_HTTP_CONNECT_TIMEOUT_SECONDS', '5'))
 JIRA_CIRCUIT_FAILURE_THRESHOLD = int(os.getenv('JIRA_CIRCUIT_FAILURE_THRESHOLD', '5'))
 JIRA_CIRCUIT_OPEN_SECONDS = float(os.getenv('JIRA_CIRCUIT_OPEN_SECONDS', '30'))
 STATS_BURNOUT_TIMEZONE = 'Europe/Berlin'
@@ -885,7 +886,8 @@ def _build_jira_unavailable_response(message, attempts=0, elapsed_seconds=0.0, u
     )
 
 
-def resilient_jira_get(url, *, params=None, headers=None, timeout=30, session=None, breaker=None,
+def resilient_jira_get(url, *, params=None, headers=None, timeout=30, connect_timeout=None,
+                       session=None, breaker=None,
                        now_fn=None, sleep_fn=None, rand_fn=None,
                        max_attempts=None, max_elapsed_seconds=None,
                        base_delay_seconds=None, max_delay_seconds=None):
@@ -895,6 +897,7 @@ def resilient_jira_get(url, *, params=None, headers=None, timeout=30, session=No
         params=params,
         headers=headers,
         timeout=timeout,
+        connect_timeout=JIRA_HTTP_CONNECT_TIMEOUT_SECONDS if connect_timeout is None else connect_timeout,
         session=session or HTTP_SESSION,
         breaker=breaker or JIRA_SEARCH_CIRCUIT_BREAKER,
         now_fn=now_fn,

--- a/tests/test_codebase_structure_budgets.py
+++ b/tests/test_codebase_structure_budgets.py
@@ -8,7 +8,9 @@ LEGACY_ENTRYPOINT_LINE_BUDGETS = {
     # feature/eng-epic-sort-and-track adds the read-only Project Track custom-field getters
     # (get_project_track_field_config/get_project_track_field_id) and threads the field id
     # into fetch_epic_details_bulk's fields list + parse.
-    "jira_server.py": 5966,
+    # bugfix/jira-connect-timeout-retry-budget adds JIRA_HTTP_CONNECT_TIMEOUT_SECONDS and
+    # threads a bounded connect_timeout through the resilient_jira_get wrapper.
+    "jira_server.py": 5969,
     # feature/eng-epic-sort-and-track adds the epic Sort dropdown wiring (engEpicSort state,
     # analytics handler, sorted epicGroups, EngView props) and the title-row priority chevron
     # plus Product Track indicator in renderEpicBlock.

--- a/tests/test_jira_resilience.py
+++ b/tests/test_jira_resilience.py
@@ -91,6 +91,32 @@ class TestJiraResilience(unittest.TestCase):
         self.assertEqual(session.get.call_count, 2)
         self.assertEqual(clock.sleeps, [0.25])
 
+    def test_connect_timeout_is_bounded_so_stalls_fail_fast(self):
+        # A hung connection must not be able to consume the whole retry budget.
+        # The per-attempt timeout is sent as a (connect, read) tuple with a short
+        # connect timeout so connection-level stalls fail fast and leave room to retry.
+        clock = _FakeClock()
+        session = Mock()
+        session.get.return_value = _mock_response(200, {'ok': True})
+        breaker = jira_server.JiraCircuitBreaker(failure_threshold=3, open_seconds=30)
+
+        jira_server.resilient_jira_get(
+            'http://jira.example/search',
+            session=session,
+            breaker=breaker,
+            now_fn=clock.now,
+            sleep_fn=clock.sleep,
+            rand_fn=lambda: 0.0,
+            max_attempts=3,
+            max_elapsed_seconds=10,
+            timeout=30,
+        )
+
+        _, kwargs = session.get.call_args
+        connect_timeout, read_timeout = kwargs['timeout']
+        self.assertLessEqual(connect_timeout, 10)
+        self.assertEqual(read_timeout, 30)
+
     def test_non_retryable_400_does_not_retry(self):
         clock = _FakeClock()
         session = Mock()


### PR DESCRIPTION
Body:
## Problem

`/api/capacity` and `/api/tasks-with-team-name` returned 500/503 because a single Jira request could hang ~26s before raising `ConnectionError`:

Jira GET transient exception type=ConnectionError attempt=1 latency_ms=26163.6
Jira search failed: status=503

`resilient_jira_get` applied a scalar 30s timeout to **both** connect and read, but the total retry budget (`max_elapsed_seconds`) is only 10s. One stalled connection consumed the entire budget on attempt 1, so the retry/backoff logic never engaged — a momentary blip became a hard 500/503 instead of a recovered retry.

`ConnectionError` is a transport-level failure (DNS/TCP/TLS/reset), not auth — confirmed it was network reachability to the upstream host, not an OAuth/token issue.

## Fix

Send a `(connect, read)` timeout tuple instead of a scalar:

- **Connect timeout** — short and configurable via `JIRA_HTTP_CONNECT_TIMEOUT_SECONDS` (default 5s). Connection-level stalls now fail fast and leave budget for a real retry that can ride out a transient blip.
- **Read timeout** — unchanged (caller value, 30s default), so legitimately slow Jira searches aren't cut short.

Targeted at `backend/jira_client.py` (core) and threaded through the `jira_server.py` wrapper. Read paths including `/api/capacity` and `/api/tasks` (`current_jira_search` → `resilient_jira_get`) are covered. Write path (`current_jira_request`) is out of scope.

This is a resilience improvement, not a guaranteed cure: a full >10s upstream outage still fails — but faster and with proper retries rather than a 26s hang.

## Verification

- New test `test_connect_timeout_is_bounded_so_stalls_fail_fast` (red before, green after).
- Full suite: **914 passed**, 1 skipped.
- Ratcheted the `jira_server.py` structure-budget line count 5966→5969 with a reason comment.
- Preflight passed; server boots and `/api/test` responds (401 auth gate, not a 500).