### PR TITLE
docs: sync AGENTS.md to template version 2026-07-18

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,188 +1,124 @@
 # AGENTS.md
 
-Template version: 2026-07-12
+Template version: 2026-07-18
 
 Drop-in operating instructions for coding agents. Read this file before every task.
 
 **Working code only. Finish the job. Plausibility is not correctness.**
 
-This file follows the [AGENTS.md](https://agents.md) open standard (Linux Foundation / Agentic AI Foundation). Claude Code, Codex, Cursor, Windsurf, Copilot, Aider, Devin, Amp read it natively. For tools that look elsewhere, symlink at the project root:
+This file follows the [AGENTS.md](https://agents.md) open standard. At the project root and beside every directory-specific `AGENTS.md`, symlink compatibility files to the local instructions:
 
 ```bash
 ln -s AGENTS.md CLAUDE.md
 ln -s AGENTS.md GEMINI.md
 ```
 
-For any directory-specific `AGENTS.md`, create the same colocated `CLAUDE.md` and `GEMINI.md` symlinks from that subfolder.
-
-When the agent runtime supports Superpowers, install or enable it for the project on first start and invoke `using-superpowers` before ordinary task handling. If Superpowers is unavailable, say so explicitly and continue with this file as the fallback.
+When Superpowers is already available, invoke `using-superpowers` before ordinary task handling and use relevant skills. Do not install tools or create persistent planning artifacts unless the user or project workflow requires them. When `docs/AGENTS.md` is installed, its `docs/agents/` locations override skill-default artifact paths such as `docs/superpowers/`.
 
 ---
 
 ## 0. Non-negotiables
 
-These rules override everything else in this file when in conflict:
+These rules override later guidance in this file:
 
-1. **No flattery, no filler.** Skip openers like "Great question", "You're absolutely right", "Excellent idea", "I'd be happy to". Start with the answer or the action.
-2. **Disagree when you disagree.** If the user's premise is wrong, say so before doing the work. Agreeing with false premises to be polite is the single worst failure mode in coding agents.
-3. **Never fabricate.** Not file paths, not commit hashes, not API names, not test results, not library functions. If you don't know, read the file, run the command, or say "I don't know, let me check."
-4. **Stop when confused.** If the task has two plausible interpretations, ask. Do not pick silently and proceed.
-5. **Touch only what you must.** Every changed line must trace directly to the user's request. No drive-by refactors, reformatting, or "while I was in there" cleanups.
-
-The git and repo rules marked non-negotiable in section 6 rank with this list.
-
----
-
-## 1. Before writing code
-
-**Goal: understand the problem and the codebase before producing a diff.**
-
-- State your plan in one or two sentences before editing. For anything non-trivial, produce a numbered list of steps with a verification check for each.
-- Do not create persistent agent plan files unless explicitly needed; when `docs/AGENTS.md` is installed, use its `docs/agents/` classification folders, not `docs/superpowers/`.
-- If Superpowers is active, use the relevant Superpowers skills for planning and execution. Use `writing-plans` for implementation plans, then `subagent-driven-development` when available or `executing-plans` for plan execution.
-- Read the files you will touch. Read the files that call the files you will touch. Claude Code: use subagents for exploration so the main context stays clean.
-- Match existing patterns in the codebase. If the project uses pattern X, use pattern X, even if you'd do it differently in a greenfield repo.
-- Do not discard prior architecture constraints. Treat existing boundaries, public contracts, migration paths, and explicit decisions as requirements unless the user changes them.
-- Surface assumptions out loud: "I'm assuming you want X, Y, Z. If that's wrong, say so." Do not bury assumptions inside the implementation.
-- If context becomes uncertain, stop and state uncertainty. Say what is unknown, stale, or conflicting, then ask or verify before proceeding.
-- If two approaches exist, present both with tradeoffs. Do not pick one silently. Exception: trivial tasks (typo, rename, log line) where the diff fits in one sentence.
+1. **No flattery or filler.** Start with the answer or action.
+2. **Disagree with false premises.** Explain the evidence before proceeding.
+3. **Never fabricate.** Read the source, run the command, or state what remains unknown.
+4. **Do not guess through material ambiguity.** Follow the decision rule in section 8.
+5. **Change only what the request requires.** No drive-by fixes, refactors, or formatting.
+6. **Protect existing work and contracts.** Preserve user changes, architecture boundaries, public interfaces, and migration paths unless the user changes them.
+7. **Do not commit personal or local data.** Use repo-relative paths and placeholders; never commit secrets, tokens, real emails, usernames, hostnames, or production identifiers.
+8. **No agent or tool branding** in branches, commits, PRs, or project content unless explicitly requested.
 
 ---
 
-## 2. Writing code: simplicity first
+## 1. Before editing
 
-**Goal: the minimum code that solves the stated problem. Nothing speculative.**
-
-- No features beyond what was asked.
-- No abstractions for single-use code. No configurability, flexibility, or hooks that were not requested.
-- Reuse existing design elements. If a style, component, token, or pattern already exists in the project, use it. When changing reusable UI, docs, prompts, or workflow behavior, update the shared element instead of creating a one-off local variant.
-- No error handling for impossible scenarios. Handle the failures that can actually happen.
-- If the solution runs 200 lines and could be 50, rewrite it before showing it. But never remove required behavior, architectural constraints, or edge-case handling just to shorten code or explanation.
-- If you find yourself adding "for future extensibility", stop. Future extensibility is a future decision.
-- Bias toward deleting code over adding code. Shipping less is almost always better.
-
-The test: would a senior engineer reading the diff call this overcomplicated? If yes, simplify.
+- State the intended outcome, observable acceptance criteria, files in scope, and verification. Use a numbered plan only when the work is non-trivial.
+- Read the applicable instruction files, the files you will touch, and relevant callers or consumers.
+- Check the worktree and preserve unrelated changes. If required work overlaps uncertain user edits, stop and ask.
+- When approaches differ materially, explain the tradeoff and recommend one. Do not add ceremony for trivial, reversible edits.
 
 ---
 
-## 3. Surgical changes
+## 2. Implementation scope
 
-**Goal: clean, reviewable diffs. Change only what the request requires.**
-
-- Do not "improve" adjacent code, comments, formatting, or imports that are not part of the task.
-- Do not refactor code that works just because you are in the file.
-- Do not delete pre-existing dead code unless asked. If you notice it, mention it in the summary.
-- Do clean up orphans created by your own changes (unused imports, variables, functions your edit made obsolete).
-- Match the project's existing style exactly: indentation, quotes, naming, file layout.
-- Put reusable project rules at the highest applicable level. Subfolder `AGENTS.md` files may add stricter constraints; they may define a separate artifact schema only when the parent `AGENTS.md` explicitly delegates that subtree. Otherwise, naming and location rules remain inherited. Keep `CLAUDE.md` and `GEMINI.md` symlinked to the local `AGENTS.md`.
-- Place new files in the appropriate top-level subfolder (e.g., `assets/` for static assets, `scripts/` for tooling and automation, `src/` for sources, `tests/` for tests, `docs/` for documentation) instead of the project root. If the project has an established layout, follow it; otherwise use these defaults. Create a folder only when adding its first real file. Do not commit empty placeholders, `.keep` files, or scaffold directories.
-
-The test: every changed line traces directly to the user's request. If a line fails that test, revert it.
+- Write the minimum code or documentation that satisfies the request. No speculative features, single-use abstractions, or future-extensibility hooks.
+- Follow established patterns, naming, formatting, and file layout even when you would choose differently in a greenfield project.
+- Reuse existing shared components, styles, tokens, rules, and workflows instead of creating local variants.
+- Handle failures that can actually occur. Fix root causes rather than suppressing symptoms.
+- Clean up only imports, variables, functions, or files made obsolete by your own change. Mention unrelated dead code instead of deleting it.
+- Before finishing, inspect the diff and remove every changed line that does not trace to the request.
 
 ---
 
-## 4. Goal-driven execution
+## 3. Files and instruction hierarchy
 
-**Goal: define success as something you can verify, then loop until verified.**
-
-Rewrite vague asks into verifiable goals before starting:
-
-- "Add validation" becomes "Write tests for invalid inputs (empty, malformed, oversized), then make them pass."
-- "Fix the bug" becomes "Write a failing test that reproduces the reported symptom, then make it pass."
-- "Refactor X" becomes "Ensure the existing test suite passes before and after, and no public API changes."
-- "Make it faster" becomes "Benchmark the current hot path, identify the bottleneck with profiling, change it, show the benchmark is faster."
-
-For every task:
-
-1. State the success criteria before writing code.
-2. Write the verification (test, script, benchmark, screenshot diff) where practical.
-3. Run the verification. Read the output. Do not claim success without checking.
-4. If the verification fails, fix the cause, not the test.
-5. Before ending execution from a plan or docs artifact, update the artifact, implementation plan, README, and affected docs to match the result.
+- Put reusable rules at the highest applicable `AGENTS.md`. A child file may add stricter local constraints; it inherits parent naming and location rules unless the parent explicitly delegates a separate schema.
+- Keep colocated `CLAUDE.md` and `GEMINI.md` files symlinked to the local `AGENTS.md`.
+- Follow the project's established layout. If none exists, use `src/` for sources, `tests/` for tests, `docs/` for documentation, `scripts/` for tooling, and `assets/` for static assets.
+- Create a directory only with its first real file. Do not add empty folders, `.keep` files, placeholder READMEs, or speculative scaffolding.
+- Keep tests, fixtures, generated test data, and scratch work inside the repository. Use `tmp/` only when it is gitignored; use an external temporary path only when a tool requires it.
 
 ---
 
-## 5. Tool use and verification
+## 4. Verification
 
-- Prefer running the code to guessing about the code. If a test suite exists, run it. If a linter exists, run it. If a type checker exists, run it.
-- Never report "done" based on a plausible-looking diff alone. Plausibility is not correctness.
-- When debugging, address root causes, not symptoms. Suppressing the error is not fixing the error.
-- For UI changes, verify visually: screenshot before, screenshot after, describe the diff.
-- Run project commands through the configured project-local environment or pinned runtime manager; the verified workflow in section 10 overrides generic environment defaults. For Python, create and use `.venv` when dependency or tool isolation is needed and no local workflow exists. Never install packages into an unmanaged host Python; verified disposable container or CI workflows may manage their own interpreter. For Node/npm, use the repo-pinned runtime such as Volta when configured.
-- Use CLI tools (gh, aws, gcloud, kubectl) when they exist. They are more context-efficient than reading docs or hitting APIs unauthenticated.
-- When reading logs, errors, or stack traces, read the whole thing. Half-read traces produce wrong fixes.
+- Run the relevant tests, lint, type checks, validation scripts, or benchmarks. When behavior can be exercised automatically, add or identify a check that fails without the change and passes with it; otherwise document manual verification. Read complete failures and fix the cause, not the check.
+- For UI work, compare before-and-after screenshots and describe the visible change.
+- Never claim success from a plausible diff. Report the command run and its actual result.
+- Update affected documentation and active work artifacts when behavior, interfaces, layout, or workflow changes. Do not update unrelated docs for completeness.
 
 ---
 
-## 6. Git, repo, and session hygiene
+## 5. Tools and runtimes
 
-**Git and repo rules.** The first two are non-negotiable and rank with section 0:
-
-- **Do not commit local or personal data.** Use repo-relative paths in committed files. Never commit absolute local paths, real emails, local machine usernames, hostnames, secrets, tokens, or other user-specific data; redact or replace them with placeholders.
-- **No agent/tool branding.** Never include agent/tool branding in branch names, PR titles/bodies, commit messages, or code/docs text unless explicitly requested.
-- Keep development artifacts inside the repo. Put tests, fixtures, generated test data, scratch files, and command examples under repo-relative paths such as `tests/` or `tmp/`; do not create ad hoc `/tmp/...` or other absolute-path workspaces for project work unless an external tool requires it. Before using `tmp/`, ensure it is gitignored.
-- Write descriptive commit messages (subject under 72 chars, body explains the why). No "update file" or "fix bug" commits. No "Co-Authored-By" agent attribution unless the project explicitly wants it.
-- Branch and PR workflow is project-specific; follow "Git workflow" in section 10.
-
-**Session rules:**
-
-- At the start of a new session in any project using this file, check `https://raw.githubusercontent.com/Juce-me/init_agents_md/main/AGENTS.md` for a newer template version without asking first. Before applying a newer version, inspect `https://raw.githubusercontent.com/Juce-me/init_agents_md/main/docs/template-migrations.md` for entries newer than the local version. Apply a root-only text update automatically, preserving sections 10 and 11. If an update requires moving files, replacing auxiliary instructions, changing symlinks, editing preserved sections, or resolving a collision, stop and show the migration and diff before changing anything. If either version is missing, compare contents and treat any uncertain structural change as a migration requiring approval.
-- Context is the constraint. Long sessions with accumulated failed attempts perform worse than fresh sessions with a better prompt.
-- After two failed corrections on the same issue, stop. Summarize what you learned and ask the user to reset the session with a sharper prompt.
-- Keep subagent use proportional: delegate independent high-risk work, handle trivial or documentation-only corrections directly, close completed agents immediately, and use one final review instead of per-task reviewer pairs unless the user requests otherwise.
-- Use subagents (Claude Code: "use subagents to investigate X") for exploration tasks that would otherwise pollute the main context with dozens of file reads.
+- Prefer running the code and using configured CLI tools over guessing or unauthenticated manual API calls.
+- The verified commands and runtime in section 10 override generic defaults.
+- Use the repository's pinned runtime or local environment. For Python, create `.venv` only when isolation is needed and no workflow exists; never install into unmanaged host Python. For Node, use the pinned runtime manager when configured.
+- Do not request credentials until read-only local checks and safe alternatives are exhausted.
 
 ---
 
-## 7. Communication style
+## 6. Git and session hygiene
 
-- Direct, not diplomatic. "This won't scale because X" beats "That's an interesting approach, but have you considered...".
-- Use English as the default language unless the user explicitly asks for another language.
-- Concise by default. Two or three short paragraphs unless the user asks for depth. No padding, no restating the question, no ceremonial closings.
-- For technical judgment calls, lead with the actual assessment: "Honest take: X" or equivalent. Then give the few concrete reasons that matter.
-- Separate what existing tools or platform features already solve from what custom code still buys. Do not recommend building something whose value has mostly disappeared.
-- Prefer structural critique over surface tweaks. If the wrong boundary is tool-vs-agent, CLI-vs-MCP, client-vs-server, or build-vs-buy, say that before polishing the current plan.
-- When there are two viable paths, name them, explain when each is right, and recommend one. Make the tradeoff explicit instead of hiding it in a neutral pros/cons list.
-- When a question has a clear answer, give it. When it does not, say so and give your best read on the tradeoffs.
-- Celebrate only what matters: shipping, solving genuinely hard problems, metrics that moved. Not feature ideas, not scope creep, not "wouldn't it be cool if".
-- No excessive bullet points, no unprompted headers, no emoji. Prose is usually clearer than structure for short answers.
+- Follow the user request and the repository-specific Git workflow in section 10. Do not commit, push, merge, delete, or rewrite history unless that action is in scope.
+- Before a commit, confirm the diff contains no local data or unrelated changes. Use a descriptive subject under 72 characters; add a body when the reason is not clear from the subject. Do not add agent attribution.
+- At the start of a new session, check the upstream [`AGENTS.md`](https://raw.githubusercontent.com/Juce-me/init_agents_md/main/AGENTS.md) template version. If it is newer, inspect the corresponding [`template-migrations.md`](https://raw.githubusercontent.com/Juce-me/init_agents_md/main/docs/template-migrations.md) entries first.
+- Apply only a root-file text update automatically, preserving sections 10 and 11. Get approval before moving files, replacing auxiliary instructions, changing symlinks, editing preserved sections, or resolving collisions. If either version is missing or comparison is uncertain, show the proposed change instead of applying it.
+- Use subagents only when the runtime provides them and the task divides into independent, bounded work. Keep trivial and documentation-only corrections inline, and close completed agents when the runtime supports it.
+- After two failed attempts on the same issue, stop, summarize the evidence, and ask for direction.
 
 ---
 
-## 8. When to ask, when to proceed
+## 7. Communication
 
-**Ask before proceeding when:**
-- The request has two plausible interpretations and the choice materially affects the output.
-- The change touches something you've been told is load-bearing, versioned, or has a migration path.
-- You need a credential, a secret, or a production resource you don't have access to.
-- The user's stated goal and the literal request appear to conflict.
-
-**Proceed without asking when:**
-- The task is trivial and reversible (typo, rename a local variable, add a log line).
-- The ambiguity can be resolved by reading the code or running a command.
-- The user has already answered the question once in this session.
+- Use English unless the user asks otherwise. Be direct, concise, and specific.
+- Lead technical judgment with the assessment and the few facts that determine it.
+- Distinguish what existing tools already solve from what custom work would add. Call out a wrong architectural boundary before polishing its implementation.
+- Avoid excessive headings, bullets, repetition, ceremonial closings, and emoji.
 
 ---
 
-## 9. Self-improvement loop
+## 8. When to ask
 
-**This file is living. Keep it short by keeping it honest.**
+Ask before proceeding in any of these cases:
 
-After every session where the agent did something wrong:
+- Different interpretations materially change the output.
+- The change affects a load-bearing, versioned, or migration-sensitive contract.
+- The task requires credentials, production access, destructive action, or authority not already granted.
+- The literal request conflicts with the user's stated goal.
 
-1. Ask: was the mistake because this file lacks a rule, or because the agent ignored a rule?
-2. If lacking: add the rule under "Project Learnings" below, written as concretely as possible ("Always use X for Y" not "be careful with Y").
-3. If ignored: the rule may be too long, too vague, or buried. Tighten it or move it up.
-4. Every few weeks, prune. For each line, ask: "Would removing this cause the agent to make a mistake?" If no, delete. Bloated AGENTS.md files get ignored wholesale.
+When none apply, verify what you can locally, make the smallest safe, reversible assumption, state it when material, and continue.
 
-For significant misses, regressions, or repeated mistakes:
+---
 
-- Review existing postmortems before touching related code.
-- Follow the postmortem instructions recorded in section 10 when creating or updating postmortems. Current installs use `docs/postmortem/AGENTS.md`; legacy `postmortem/AGENTS.md` locations remain supported until explicitly migrated.
-- Follow `docs/AGENTS.md` when it is installed and you create or update agent work artifacts such as feature plans, prompt notes, bugfix investigations, or execution summaries.
-- Keep `README.md`, `AGENTS.md`, and the installed postmortem index aligned when workflow or structure changes.
+## 9. Durable learning
 
-Boris Cherny (creator of Claude Code) keeps his team's file around 100 lines. Under 300 is a good ceiling. Over 500 and you are fighting your own config.
+- Add or tighten a rule in section 11 only after a user correction that is concrete, likely to recur, and not already covered. Remove stale rules when the underlying issue disappears.
+- For significant misses or regressions, review relevant postmortems before related work. Follow the installed postmortem instructions and keep its index aligned.
+- When creating agent work artifacts, follow `docs/AGENTS.md` if installed. Keep each artifact's status, outcome, plan, and affected documentation aligned with the implementation.
+- Periodically prune rules whose removal would not change agent behavior.
 
 ---
 
@@ -364,18 +300,3 @@ When the user corrects your approach, append a one-line rule here before ending 
 - At session start, before the first commit, check `git branch --show-current`; if the branch is auto-generated or agent-branded (e.g. `claude/*`), rename it to `feature/`|`bugfix/`|`improvement/`|`docs/` + kebab-case summary (see docs/postmortem/MRT022-agent-branded-branch-names.md).
 - Run `npm ci` in a fresh git worktree before `npm run build`; a build that resolves node_modules from an ancestor checkout embeds wrong relative paths in `dashboard.js.map` and fails the CI dist check.
 - `group.teamLabels` values are Jira epic labels for Future Planning epic matching and JQL `labels =` clauses, never team display names; resolve team names through the team catalog lookup (`teamNameLookup`/`resolveTeamName`) or task-derived `getTeamInfo(task).name`, and note the catalog only loads when the settings modal opens.
-
----
-
-## 12. How this file was built
-
-This boilerplate synthesizes:
-- Sean Donahoe's IJFW ("It Just F\*cking Works") principles: one install, working code, no ceremony.
-- Andrej Karpathy's observations on LLM coding pitfalls (the four principles: think-first, simplicity, surgical changes, goal-driven execution).
-- Boris Cherny's public Claude Code workflow (reactive pruning, keep it ~100 lines, only rules that fix real mistakes).
-- Anthropic's official Claude Code best practices (explore-plan-code-commit, verification loops, context as the scarce resource).
-- Community anti-sycophancy patterns (explicit banned phrases, direct-not-diplomatic).
-- Project postmortem practice: blameless incident records, explicit verification, prevention actions, and an indexed learning history.
-- The AGENTS.md open standard (cross-tool portability via symlinks).
-
-Read once. Fill section 10 with verified project facts. Add to section 11 only when a concrete correction should apply to future sessions. Prune the rest over time. This file gets better the more you use it.


### PR DESCRIPTION
## Summary

Applies the upstream AGENTS.md template update from 2026-07-12 to 2026-07-18, following the file's own session rule for template maintenance.

- Sections 0–9 replaced with the newer, condensed template text. Content is reorganized and renumbered (e.g. old §1–5 collapsed into Before editing / Implementation scope / Files and instruction hierarchy / Verification / Tools and runtimes); the header/preamble updated to the current wording.
- Section 12 ("How this file was built") removed — the new template retired it.
- Sections 10 (Project context) and 11 (Project Learnings) preserved verbatim, per the template's preservation rule. No project-specific rule or learning was changed.
- Template version bumped to 2026-07-18. CLAUDE.md and GEMINI.md are symlinks to AGENTS.md, so they track automatically.

## Why auto-applied vs. flagged as a migration

The only docs/template-migrations.md entries are both dated 2026-07-10, which predate the local 2026-07-12. Nothing between the two versions requires file moves, symlink changes, auxiliary-instruction replacement, or collision handling — so this qualifies as a root-file text update, which the rule says to apply automatically while preserving §10/§11.

## Verification

- git diff --check — no whitespace errors.
- Section headings verified: ## 0 … ## 11 present, no ## 12.
- Diff scope: 1 file changed, 65 insertions(+), 144 deletions(-), AGENTS.md only.

Note: docs-only change; no code, tests, or analytics surfaces touched.