### PR TITLE
fix: update cryptography security pin

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,5 +8,5 @@ SQLAlchemy==2.0.44
 alembic==1.14.0
 psycopg[binary]==3.2.13
 google-auth==2.56.2
-cryptography==46.0.7
+cryptography==50.0.0
 gunicorn==23.0.0

--- a/tests/test_env_config_docs.py
+++ b/tests/test_env_config_docs.py
@@ -63,6 +63,20 @@ class EnvConfigDocsTests(unittest.TestCase):
                 self.assertIn("OpenSSL 1.1.1+", text)
                 self.assertIn("LibreSSL", text)
 
+    def test_requirements_pin_security_fixed_cryptography(self):
+        requirements = (REPO_ROOT / "requirements.txt").read_text(encoding="utf8").splitlines()
+        cryptography_pins = [
+            line.strip()
+            for line in requirements
+            if line.strip().lower().startswith("cryptography==")
+        ]
+
+        self.assertEqual(len(cryptography_pins), 1)
+        match = re.fullmatch(r"cryptography==(\d+)\.(\d+)\.(\d+)", cryptography_pins[0], re.IGNORECASE)
+        self.assertIsNotNone(match)
+        version = tuple(int(part) for part in match.groups())
+        self.assertGreaterEqual(version, (50, 0, 0))
+
     def test_hosted_container_env_contract_is_documented(self):
         docs = (
             REPO_ROOT / ".env.example",


### PR DESCRIPTION
## Summary

- Upgrade `cryptography` from `46.0.7` to `50.0.0`.
- Resolve four known security advisories reported by `pip-audit`.
- Add a regression test preventing the dependency from being pinned below the fixed version.

## Verification

- Python audit: no known vulnerabilities in the resolved environment.
- npm audit: 0 vulnerabilities across 34 dependencies.
- Python: 1,136 tests passed, 1 skipped.
- Frontend: 558 tests passed.
- Frontend build completed with no generated-file diff.
- Startup preflight passed.
- Live `/api/test` smoke check returned HTTP 200.
- `pip check` reported no broken requirements.

The Python suite still emits pre-existing unrelated `ResourceWarning` messages.

## Analytics and UI

- Analytics impact: none; dependency-only change.
- UI impact: none; screenshots are not applicable.
