### PR TITLE
Fix department group selector hover readability

### DIFF
--- a/frontend/dist/dashboard.css
+++ b/frontend/dist/dashboard.css
@@ -1756,6 +1756,12 @@ h1 {
   text-align: left;
   color: inherit;
 }
+.group-list-select:hover {
+  background: transparent;
+  color: inherit;
+  box-shadow: none;
+  transform: none;
+}
 .group-list-name-input {
   min-width: 0;
   min-height: 44px;

--- a/frontend/src/styles/settings/team-selector.css
+++ b/frontend/src/styles/settings/team-selector.css
@@ -179,6 +179,13 @@
             color: inherit;
         }
 
+        .group-list-select:hover {
+            background: transparent;
+            color: inherit;
+            box-shadow: none;
+            transform: none;
+        }
+
         .group-list-name-input {
             min-width: 0;
             min-height: 44px;

--- a/tests/ui/shared_department_groups.spec.js
+++ b/tests/ui/shared_department_groups.spec.js
@@ -2569,6 +2569,21 @@ test('personal favorite star is separate from shared default and temporary group
     ];
     const rows = dialog.locator('.group-list-item');
     await expect(rows).toHaveCount(rowExpectations.length);
+    const platformGroupSelect = rows.nth(1).locator('.group-list-select');
+    await platformGroupSelect.hover();
+    await expect.poll(() => platformGroupSelect.evaluate((node) => {
+        const style = getComputedStyle(node);
+        return {
+            backgroundColor: style.backgroundColor,
+            boxShadow: style.boxShadow,
+            transform: style.transform,
+        };
+    })).toEqual({
+        backgroundColor: 'rgba(0, 0, 0, 0)',
+        boxShadow: 'none',
+        transform: 'none',
+    });
+    await captureSettledDepartmentScreenshot(page, 'department-row-selector-hover.png');
     await rows.nth(1).click();
     await expect(dialog.locator('.group-star-button')).toHaveCount(0);
     for (let index = 0; index < rowExpectations.length; index += 1) {


### PR DESCRIPTION
## Summary

- Prevent hover styling from obscuring department group selector text.
- Preserve the selector’s transparent background, inherited text color, and stable geometry.
- Add a Playwright regression assertion and settled hover screenshot coverage.
- Rebuild the generated frontend CSS output.

## Testing

- Playwright UI coverage updated for the department group selector hover state.
- Generated frontend assets updated from source.'
pull request create failed: GraphQL: Resource not accessible by personal access token (createPullRequest)