### PR TITLE
Fix local runner replacement and publication checks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -195,6 +195,14 @@ Prefer single-file or single-test runs during iteration. Run the full suite befo
 - Keep commits atomic and honest. Do not claim measured improvements you did not verify.
 - For UI changes, include screenshots in the PR notes.
 - Before push, run the full test suite, review `git log --oneline -5`, and wait for explicit user confirmation.
+- Treat commit, push, and PR creation as one blocking publication transaction. Before the first publication mutation:
+  1. Fetch the intended base and record the exact base and head SHAs.
+  2. Run `git status --short`, `git log --oneline origin/<base>..HEAD`, and `git diff --name-status origin/<base>...HEAD`.
+  3. Compare the complete commit list, commit count, and every changed path with the approved plan and publication contract. A clean worktree is insufficient. If history or scope differs, stop before commit/push/PR and ask the operator whether to reconstruct it; do not stack cleanup commits or rewrite history without explicit authorization.
+  4. Run the required verification and committed-revision build at the exact proposed head.
+  5. Send multiline PR Markdown through stdin with `gh pr create --body-file -` or `gh pr edit --body-file -`. Never pass JSON-stringified, backslash-escaped, or command-substituted multiline content through `--body`.
+  6. Before reporting success, prove the remote head equals the approved local head, read back the body as rendered text (not serialized JSON), visually inspect the GitHub PR page, verify the remote changed-file list and commit count, and report the actual CI state.
+  7. If any post-publication check fails, report the publication as malformed and stop for operator direction. A successful CLI exit code is not proof of a correct PR.
 - Do not use the `using-git-worktrees` skill in this repo unless the user explicitly asks for a worktree.
 
 ---
@@ -317,7 +325,10 @@ When the user corrects your approach, append a one-line rule here before ending 
 - In main ENG view filters, keep `.eng-mode-control` intrinsic-width, use the flexible gap after Teams for right alignment, and bottom-align it with the dropdown controls.
 - Global heading rules also affect Jira-rendered description headings inside `.m-desc-body`; do not apply entrance animations to H1 elements.
 - Keep localhost and CI runner assets under `runners/local/` and `runners/github/`; never mix them into application source, production startup, deployment images, or release packaging.
+- Local runner lock acquisition must distinguish an unavailable lock path from contention, fall back to the system user temp directory when `/tmp` is unavailable, and succeed or fail after one report; never loop on the same missing or stale state.
 - When the user explicitly excludes a gate document from an execution plan, do not read or modify that gate during the execution.
 - Catch Up onboarding must never require cross-surface activation; keep Next enabled, let Next open field previews, and advance exactly once from the preview surface, a preview choice, the same field, or Next without mutating Jira.
 - When a persisted shared mapping is complete but unverified, Settings must expose it as an unsaved re-verification state and call the owning verification endpoint even when its visible values are unchanged.
 - When head-stamped migration drift affects multiple objects, stop piecemeal repairs: collect a schema-only inventory, diff it against a clean current head, reconcile the complete gap set in one forward revision, and verify exact schema parity plus affected ORM contracts.
+- Never bypass the section 10 publication transaction gate; validate history, scope, remote head, rendered PR body, and CI as one unit before reporting success (MRT025).
+- Commit a postmortem for active work on the related task branch; do not create a separate postmortem/docs branch unless the operator explicitly requests one.

--- a/docs/agents/bugfixes/2026-09-07-executed-local-runner-replacement.md
+++ b/docs/agents/bugfixes/2026-09-07-executed-local-runner-replacement.md
@@ -1,0 +1,89 @@
+# Local Runner Replacement
+
+Status: executed
+Type: bugfix
+
+## Goal
+
+Starting `./runners/local/run.sh` replaces an existing instance of that same runner instead of failing on its fixed lock, while stale locks are recovered and unrelated processes are never signalled.
+
+## Design
+
+The lock directory remains the host-user serialization boundary. It uses `/tmp` when available and falls back to the operating system's per-user temporary directory. Its owner writes its PID to `runner.pid` immediately after `mkdir` succeeds. A contender reads that PID, verifies that the process command line identifies `runners/local/run.sh`, sends `TERM`, and waits for the old runner to finish its existing exact-project Docker cleanup. If the old runner does not exit within the bounded grace period, the contender sends `KILL`. Missing, malformed, dead, or non-runner PID metadata is treated as stale state and the lock directory is reclaimed without signalling the referenced process.
+
+Lock reclamation stays race-safe: removal only targets the fixed lock's PID file and directory, acquisition always uses atomic `mkdir`, and contenders retry rather than assuming ownership after removal. Cleanup removes the PID file before removing the owned directory.
+
+## Files
+
+- Modify `tests/test_local_postgresql_runner.py`: cover active-runner replacement, stale lock recovery, non-runner PID safety, and replacement escalation.
+- Modify `runners/local/run.sh`: publish owner PID, validate and stop an existing owner, reclaim stale locks, and acquire through a bounded retry loop.
+- Modify `runners/local/README.md`: describe automatic replacement and stale-lock recovery.
+
+## Implementation Plan
+
+### Task 1: Specify replacement behavior
+
+- [x] Replace the existing concurrent-runner rejection test with a process test that starts a sleeping runner, starts a second runner, and proves the first exits through cleanup before the second reaches Flask.
+- [x] Add stale-lock tests for empty and malformed PID metadata and prove startup succeeds.
+- [x] Add a safety test whose `runner.pid` names a live unrelated process and prove that process remains alive while startup succeeds.
+- [x] Run `python3 -m unittest tests.test_local_postgresql_runner` and confirm the new assertions fail because the original runner neither writes PID metadata nor replaces an owner.
+
+### Task 2: Implement bounded ownership replacement
+
+- [x] Add lock-owner helpers to read numeric PID metadata, validate the target command line as this runner, send `TERM`, wait in short bounded intervals, and send `KILL` only after the grace period.
+- [x] Change acquisition to retry atomic `mkdir`, reclaim stale metadata without signalling unrelated processes, and write `$$` to `runner.pid` before declaring ownership.
+- [x] Publish the active child process-group PID so forced takeover also terminates the old runner's child tree.
+- [x] Change cleanup to remove owned PID metadata before `rmdir`.
+- [x] Run `python3 -m unittest tests.test_local_postgresql_runner` and confirm all focused process tests pass.
+
+### Task 3: Align documentation and verify
+
+- [x] Update `runners/local/README.md` so restart behavior matches the implementation and manual lock removal is no longer the normal recovery path.
+- [x] Run `bash -n runners/local/run.sh` and require exit status 0.
+- [x] Run `python3 -m unittest tests.test_local_postgresql_runner tests.test_postgresql_runner_contract` and confirm 46 tests pass.
+- [x] Run the full suite with explicit JSON-file/basic test mode and confirm 1,545 tests pass with 9 skipped.
+- [x] Run `git diff --check` and inspect the scoped diff for unrelated changes.
+
+### Task 4: Bound unreclaimable stale-lock failure
+
+- [x] Add a process regression proving an unreclaimable stale lock is reported once and exits promptly.
+- [x] Stop suppressing stale-lock removal failures; retry only when the observed owner metadata changed concurrently.
+- [x] Document the single-report failure behavior and add the durable project rule.
+
+### Task 5: Handle concurrent lock disappearance
+
+- [x] Reproduce the prior runner removing the directory between observation and `rmdir` completion.
+- [x] Treat a failed `rmdir` as success when the exact lock directory no longer exists.
+- [x] Keep an existing unreclaimable directory on the immediate single-report failure path.
+
+### Task 6: Handle an unavailable `/tmp`
+
+- [x] Reproduce the real failure with `bash -x` and prove `mkdir` failed because `/tmp` was unavailable while the retry loop misclassified the absent path as a stale lock.
+- [x] Add a regression proving lock creation failure exits once without entering stale-lock reclamation.
+- [x] Fall back to the operating system's per-user temporary directory when `/tmp` is unavailable.
+- [x] Start the real runner through migrations, preflight, and Flask; then start a second real runner and prove it terminates and replaces the first.
+
+## Acceptance Criteria
+
+- A second invocation stops a live instance of `runners/local/run.sh`, waits for its cleanup, and then starts normally.
+- A stale or corrupt lock no longer blocks startup.
+- A PID that belongs to an unrelated live process is never signalled.
+- Replacement is bounded and can escalate from `TERM` to `KILL`.
+- Existing signal forwarding, exact Docker cleanup, persistent-volume retention, localhost isolation, and exit-status behavior remain covered.
+- Analytics impact: no event is added because this is developer tooling with no user-visible application interaction.
+
+## Forbidden Regressions
+
+- Do not match or kill processes by a broad name search.
+- Do not signal a PID without validating its command line.
+- Do not use broad Docker cleanup or remove the retained volume.
+- Do not change application, deployment, or frontend behavior.
+- Do not modify the unrelated work already present on this branch.
+
+## Outcome
+
+Implemented with changes. The runner now records both its own PID and its active child process-group PID, replaces a validated live runner with bounded `TERM`/`KILL` handling, and automatically reclaims empty, malformed, dead, or unrelated PID locks. The child PID metadata was added during implementation so forced replacement cannot leave the old Flask process tree behind. An unreclaimable stale lock now produces one report and exits immediately instead of suppressing the removal failure and retrying the same state. If the prior runner concurrently removes the observed directory, reclamation recognizes that postcondition as success and continues startup. A failed lock `mkdir` is no longer treated as stale contention: startup uses the system per-user temp directory when `/tmp` is unavailable and otherwise fails once with a lock-creation error.
+
+## Current Accuracy
+
+Accurate. The implementation, focused process tests, source-contract tests, runner guide, and verification results match this artifact.

--- a/docs/postmortem/MRT025-pr-publication-transaction-failures.md
+++ b/docs/postmortem/MRT025-pr-publication-transaction-failures.md
@@ -1,0 +1,112 @@
+# Postmortem MRT025: PR Publication Transaction Failures
+
+**Date**: 2026-09-08
+**Severity**: High
+**Status**: In Progress
+**Author**: Codex execution session
+
+## Summary
+
+Publication of Board Configuration horizontal scrolling in PR #170 repeated a commit and pull-request procedure failure that the operator reports has now occurred four times. The session treated a successful commit, push, and `gh pr` exit code as completion without first proving the proposed commit range, remote file set, commit history, and rendered pull-request body together.
+
+The first published PR included unrelated environment and local-runner changes. Cleanup commits reduced the final file diff to the ten planned files, but the PR retained six commits rather than the requested atomic publication history. The PR description was passed through a JavaScript-to-shell quoting boundary that converted Markdown line breaks into literal `\n` text. The same unsafe construction was used twice, and JSON readback was accepted without inspecting the rendered GitHub result. The operator's screenshot, not the publication procedure, exposed the malformed description.
+
+## Impact
+
+- Reviewers received a malformed, difficult-to-read PR description containing literal `\n` sequences.
+- PR #170 initially exposed files outside the immutable execution-plan map.
+- Two cleanup commits were required after the PR opened, increasing the PR to six commits and violating the requested atomic publication procedure.
+- The operator had to inspect the GitHub UI and report a recurrence that automated and command-line verification should have caught.
+- Product code and generated assets were not corrupted; the final PR file diff was reduced to the intended ten files and CI passed.
+
+## Root Cause
+
+The publication workflow was not treated as one gated transaction.
+
+1. **The wrong Git state was verified.** The session checked that the working tree was clean and that the latest local tests passed, but did not first run and approve both `git log origin/main..HEAD` and `git diff --name-status origin/main...HEAD`. A clean working tree says nothing about unrelated commits already present in the branch.
+2. **The immutable file map was checked after publication.** Remote PR metadata was inspected only after `gh pr create`. This reversed the required order: the proposed remote range must be proven before any push or PR creation.
+3. **Atomicity was reduced to final-tree correctness.** Once unrelated changes were found, follow-up cleanup and outcome commits were added. The final file tree became correct, but the requested single atomic publication did not. The session should have stopped and requested authorization for a clean-history reconstruction instead of silently converting a history problem into more commits.
+4. **Markdown crossed an unsafe encoding boundary.** The PR body was constructed with `JSON.stringify(body)` and interpolated into a shell command using `--body`. JSON escapes newlines as `\n`; a shell double-quoted argument does not translate `\n` into line breaks, so GitHub stored the backslash and `n` characters.
+5. **Verification checked data, not presentation.** `gh pr view --json body` was read as serialized JSON and the GitHub page was not visually inspected. The procedure therefore confirmed that text existed but not that Markdown rendered correctly.
+6. **There was no recurrence gate.** Existing guidance covered branch naming, allowed files, build reproducibility, and waiting for push authorization, but did not define one mandatory pre-push/PR checklist with a stop condition. The operator's report that this is the fourth occurrence shows that reminders distributed across instructions have not been sufficient.
+
+## Timeline
+
+- 2026-09-07: Commit `7addded` recorded the feature implementation but also contained unrelated local-runner work; the branch ancestry also carried an unrelated environment example change.
+- 2026-09-08: The operator authorized commit, push, and PR creation.
+- The session found local commit `6ceb9c8` after beginning publication verification and preserved it on a separate local runner branch.
+- The session explicitly pushed feature SHA `7addded`, then opened PR #170 before inspecting the PR's complete remote diff and commit range.
+- GitHub reported 13 changed files, including `.env.example`, a local-runner work artifact, and a local-runner test.
+- Cleanup commit `9429b55` removed those three files from the final PR diff.
+- Outcome commit `4a27ba9` updated the execution plan after publication, bringing the PR to six commits.
+- Both `gh pr create` and `gh pr edit` passed a JSON-stringified body through the shell. Both commands exited successfully while preserving literal `\n` characters.
+- All four GitHub checks passed, but no rendered-body check was performed.
+- At 10:06 CEST, the operator supplied a GitHub screenshot showing the malformed PR description and identified the fourth recurrence.
+
+## Resolution
+
+Completed containment:
+
+- The unrelated runner commit remains preserved on a separate local branch and was not pushed into PR #170.
+- The final PR file diff contains exactly the ten files allowed by the reviewed plan.
+- At the operator's correction, this postmortem was moved onto the related `bugfix/local-runner-lock-replacement` branch and the incorrectly created dedicated docs branch was deleted locally and remotely.
+- A root `AGENTS.md` publication rule now makes commit-range, file-map, body-input, rendered-body, and remote-head checks one mandatory gate.
+- PR #170's body was replaced through `gh pr edit --body-file -`; CLI readback contained real line breaks, an explicit check found no literal `\n` sequences, and the operator confirmed the rendered PR looks normal.
+
+Still requiring operator direction:
+
+- Decide whether PR #170's six-commit history should be reconstructed as the requested atomic publication. That would require an explicitly authorized history rewrite and force-push; this postmortem does not infer that authority.
+
+## Verification
+
+- The operator screenshot shows literal `\n` sequences throughout the PR summary and verification sections.
+- GitHub reported PR #170 at head `4a27ba9` with six commits.
+- The final GitHub file list contains the intended ten files, confirming that file containment was repaired but commit atomicity was not.
+- GitHub's four CI checks passed, demonstrating that CI correctness did not detect presentation or publication-history defects.
+- `gh pr view --json body --jq .body` returned normally formatted multiline Markdown after the repair, and `.body | contains("\\n")` returned `false`; the operator confirmed PR #170 looks normal without further browser automation.
+- `git branch --show-current` reports `bugfix/local-runner-lock-replacement` for these documentation changes; that branch has no upstream association with PR #170.
+
+## Lessons Learned
+
+- A clean working tree is not evidence of a clean PR. Publication scope is the merge-base-to-head commit range.
+- Correct final files and correct commit history are separate acceptance criteria.
+- A successful CLI exit code proves transport success, not correct Markdown rendering.
+- Any content crossing JavaScript, shell, CLI, JSON, and Markdown boundaries must use an input mechanism that preserves bytes without re-escaping.
+- Post-publication checks are containment, not substitutes for pre-publication gates.
+- A fourth recurrence requires a procedural stop gate, not another reminder to be careful.
+
+## Action Items
+
+- [x] Document the repeated failure and its verified causes in MRT025.
+- [x] Add a repository-wide PR publication transaction rule to root `AGENTS.md`.
+- [x] Commit MRT025 on `bugfix/local-runner-lock-replacement` and delete the mistakenly created dedicated docs branch.
+- [x] Verify that PR #170's final file diff contains exactly the ten planned files.
+- [x] Repair PR #170 through stdin, verify it contains no literal escaped newlines, and record the operator's rendered-page confirmation.
+- [ ] Ask the operator whether to reconstruct PR #170 as one atomic publication commit; do not force-push without explicit authorization.
+- [ ] Before every future PR, capture the approved base/head SHAs, exact commit list, exact changed-file list, clean status, and rendered PR body in one final evidence block.
+
+## Prevention
+
+Treat publication as an all-or-stop transaction:
+
+1. Fetch the target base and resolve immutable base and head SHAs.
+2. Run `git status --short`, `git log --oneline origin/main..HEAD`, and `git diff --name-status origin/main...HEAD` before committing or pushing.
+3. Compare the commit count and every changed path with the approved publication contract. If either differs, stop before push/PR and ask whether history may be reconstructed.
+4. Run the required tests and committed-revision build at the exact proposed head.
+5. Send multiline PR Markdown through stdin with `gh pr create --body-file -` or `gh pr edit --body-file -`; never synthesize it with JSON escaping inside a shell `--body` argument.
+6. Read back the body as rendered text, inspect the GitHub page, verify the remote head SHA and changed-file list, and only then report publication complete.
+7. If any post-publication check fails, report the PR as malformed and stop. Do not stack cleanup commits or rewrite history without operator authorization.
+
+## Related Issues
+
+- [MRT016](./MRT016-exec-02-plan-file-map-drift.md): file-map validation must precede execution and publication.
+- [MRT022](./MRT022-agent-branded-branch-names.md): recurring Git-process failures require an explicit session gate.
+- [PR #170](https://github.com/Juce-me/jira-execution-planner/pull/170)
+- [Issue #167](https://github.com/Juce-me/jira-execution-planner/issues/167)
+
+## References
+
+- Commits `7addded`, `9429b55`, and `4a27ba9`.
+- Operator screenshot captured 2026-09-08 at 10:06 CEST.
+- Root `AGENTS.md` Git workflow and project learnings.
+- `docs/plans/EXEC-board-configuration-horizontal-scroll.md` atomic publication requirement.

--- a/docs/postmortem/README.md
+++ b/docs/postmortem/README.md
@@ -41,6 +41,7 @@ Postmortems serve to:
 | [MRT022](./MRT022-agent-branded-branch-names.md) | Agent-Branded Branch Names Ignored Git Conventions | 2026-07-08 | Low | Resolved | Sessions repeatedly started on auto-generated `claude/*` branches despite AGENTS.md forbidding tool branding and requiring typed branch prefixes; fixed with a session-start rename rule in AGENTS.md section 11 |
 | [MRT023](./MRT023-alert-enrichment-blocked-first-screen.md) | Alert Enrichment Blocked the First Screen | 2026-08-08 | High | Resolved | Alert-only Epic distribution work consumed 10.367 seconds on the primary ENG task response and alert sources ran outside Catch Up |
 | [MRT024](./MRT024-head-stamped-schema-drift.md) | Head-Stamped Schema Drift | 2026-09-02 | High | Resolved | Alembic reported head while a preserved local PostgreSQL volume had duplicate onboarding columns and missing auth/capacity schema objects |
+| [MRT025](./MRT025-pr-publication-transaction-failures.md) | PR Publication Transaction Failures | 2026-09-08 | High | In Progress | A repeated publication failure mixed unrelated commit history into a feature PR and rendered JSON-escaped newlines literally because remote range and rendered-body gates ran too late |
 
 ## Postmortem Template
 
@@ -94,8 +95,8 @@ Commits, files, documentation
 
 ## Statistics
 
-- **Total postmortems**: 24
-- **Metadata complete (Date/Severity/Status)**: 24 (MRT001-MRT024)
+- **Total postmortems**: 25
+- **Metadata complete (Date/Severity/Status)**: 25 (MRT001-MRT025)
 
 ## Common Themes
 
@@ -104,6 +105,7 @@ Commits, files, documentation
 2. **Algorithm Validation**: Need peer review for complex algorithms
 3. **Backend/Frontend Alignment**: Frontend didn't match backend logic
 4. **Performance**: Missing optimization guards in React hooks
+5. **Publication Hygiene**: Local cleanliness and successful CLI exits were mistaken for a correct remote commit range and rendered PR
 
 ### Action Items Summary
 Across all postmortems, key actions needed:
@@ -153,5 +155,5 @@ For questions about postmortems or to discuss issues, contact the development te
 
 ---
 
-*Last Updated: 2026-09-02*
-*Total Postmortems: 24*
+*Last Updated: 2026-09-08*
+*Total Postmortems: 25*

--- a/runners/local/README.md
+++ b/runners/local/README.md
@@ -12,12 +12,10 @@ Prerequisites: Docker Engine 28+ with a local Unix-socket context, Docker Compos
 
 Press `Ctrl+C` to stop Flask and remove the runner's PostgreSQL container and network. The `jira-planning-local-postgres` volume remains, so database data survives the next run. Docker prune, Docker Desktop reset, or manual volume deletion can still remove it.
 
+Starting the command again while another local runner is active stops that runner and waits for its cleanup before taking ownership. Shutdown first uses `TERM`; if the old runner does not exit within the bounded grace period, replacement escalates to `KILL` and terminates the child process group recorded by that runner.
+
 The runner always binds Flask and PostgreSQL to `127.0.0.1`, accepts no overrides, and refuses remote Docker contexts or ambiguous existing runner resources. The `jep`/`jep` database credentials are for this dedicated local container only. Docker access is host-administrator access, and the retained volume can contain sensitive local configuration or encrypted token records.
 
-If a prior process was killed without cleanup, inspect the exact `jira-planning-local` Compose project and the lock path reported by the runner. Do not use broad Docker prune commands or `backend.db.reset_local` as lifecycle cleanup.
+The lock records the runner PID. It uses `/tmp` when available and otherwise uses the operating system's per-user temporary directory. Startup validates that the live PID belongs to `runners/local/run.sh` before signalling it; it does not signal unrelated processes. If the PID is missing, malformed, dead, or belongs to another command, startup reclaims stale or corrupt lock metadata automatically. If the lock path cannot be created, contains unexpected entries, or cannot be removed, startup reports the problem once and exits with an actionable error instead of retrying. Existing exact-project Docker resource checks still fail closed, so ambiguous containers, networks, or volume users are never removed as stale lock cleanup.
 
-Only after confirming that no runner process is active and no exact `jira-planning-local` Compose project, container, network, or volume user is active, remove only the empty fixed lock directory with:
-
-```bash
-rmdir /tmp/jira-planning-local-runner.lock
-```
+If startup reports ambiguous runner resources after lock recovery, inspect only the exact `jira-planning-local` Compose project named in the error. Do not use broad Docker prune commands or `backend.db.reset_local` as lifecycle cleanup.

--- a/runners/local/run.sh
+++ b/runners/local/run.sh
@@ -7,7 +7,15 @@ readonly compose_file="${script_dir}/compose.yaml"
 readonly project_name="jira-planning-local"
 readonly volume_name="jira-planning-local-postgres"
 readonly python_bin="${repo_root}/.venv/bin/python"
-readonly lock_dir="/tmp/jira-planning-local-runner.lock"
+runtime_tmp_dir="/tmp"
+if [[ ! -d "$runtime_tmp_dir" || ! -w "$runtime_tmp_dir" ]]; then
+  runtime_tmp_dir="$(getconf DARWIN_USER_TEMP_DIR 2>/dev/null || true)"
+  runtime_tmp_dir="${runtime_tmp_dir%/}"
+fi
+readonly runtime_tmp_dir
+readonly lock_dir="${runtime_tmp_dir}/jira-planning-local-runner.lock"
+readonly lock_pid_file="${lock_dir}/runner.pid"
+readonly lock_child_pid_file="${lock_dir}/child.pid"
 
 cleanup_armed=0
 cleanup_done=0
@@ -21,12 +29,134 @@ fail() {
   exit 1
 }
 
+process_is_running() {
+  local target_pid="$1"
+
+  kill -0 "$target_pid" 2>/dev/null
+}
+
+pid_belongs_to_runner() {
+  local target_pid="$1"
+  local process_command=""
+
+  process_command="$(ps -p "$target_pid" -o command= 2>/dev/null)" || return 1
+  [[ "$process_command" == *"runners/local/run.sh"* ]]
+}
+
+remove_observed_lock() {
+  local observed_pid="$1"
+  local current_pid=""
+
+  if [[ -f "$lock_pid_file" ]]; then
+    current_pid="$(< "$lock_pid_file")"
+  fi
+  [[ "$current_pid" == "$observed_pid" ]] || return 2
+  rm -f -- "$lock_child_pid_file" || return 1
+  rm -f -- "$lock_pid_file" || return 1
+  if ! rmdir "$lock_dir" 2>/dev/null; then
+    [[ ! -d "$lock_dir" ]] || return 1
+  fi
+}
+
+stop_existing_runner() {
+  local target_pid="$1"
+  local target_child_pid=""
+  local attempt=0
+
+  printf 'Local PostgreSQL runner: replacing runner process %s.\n' \
+    "$target_pid" >&2
+  kill -TERM "$target_pid" 2>/dev/null || return 0
+  while process_is_running "$target_pid" &&
+        [[ -d "$lock_dir" && "$attempt" -lt 140 ]]; do
+    sleep 0.05
+    attempt=$((attempt + 1))
+  done
+  if process_is_running "$target_pid" && [[ -d "$lock_dir" ]]; then
+    printf 'Local PostgreSQL runner: runner process %s did not stop; sending KILL.\n' \
+      "$target_pid" >&2
+    if [[ -f "$lock_child_pid_file" ]]; then
+      target_child_pid="$(< "$lock_child_pid_file")"
+    fi
+    kill -KILL "$target_pid" 2>/dev/null || true
+    if [[ "$target_child_pid" =~ ^[0-9]+$ ]]; then
+      kill -TERM -- "-${target_child_pid}" 2>/dev/null || true
+      kill -KILL -- "-${target_child_pid}" 2>/dev/null || true
+    fi
+    remove_observed_lock "$target_pid" || true
+  fi
+  if process_is_running "$target_pid" && [[ -d "$lock_dir" ]]; then
+    fail "unable to stop existing runner process ${target_pid}."
+  fi
+}
+
+acquire_lock() {
+  local acquisition_attempt=0
+  local owner_pid=""
+  local publication_attempt=0
+  local removal_status=0
+
+  while [[ "$acquisition_attempt" -lt 20 ]]; do
+    acquisition_attempt=$((acquisition_attempt + 1))
+    critical_section=1
+    if mkdir "$lock_dir" 2>/dev/null; then
+      lock_owned=1
+      chmod 700 "$lock_dir"
+      printf '%s\n' "$$" > "$lock_pid_file"
+      critical_section=0
+      service_pending_signal
+      return 0
+    fi
+    critical_section=0
+    service_pending_signal
+
+    [[ -d "$lock_dir" ]] ||
+      fail "unable to create runner lock: ${lock_dir}"
+
+    publication_attempt=0
+    while [[ ! -f "$lock_pid_file" && "$publication_attempt" -lt 20 ]]; do
+      [[ -d "$lock_dir" ]] || break
+      sleep 0.05
+      publication_attempt=$((publication_attempt + 1))
+    done
+    if [[ -f "$lock_pid_file" ]]; then
+      owner_pid="$(< "$lock_pid_file")"
+    else
+      owner_pid=""
+    fi
+
+    if [[ "$owner_pid" =~ ^[0-9]+$ ]] &&
+       process_is_running "$owner_pid" &&
+       pid_belongs_to_runner "$owner_pid"; then
+      stop_existing_runner "$owner_pid"
+      continue
+    fi
+
+    printf 'Local PostgreSQL runner: reclaiming stale runner lock: %s\n' \
+      "$lock_dir" >&2
+    if remove_observed_lock "$owner_pid"; then
+      continue
+    else
+      removal_status=$?
+    fi
+    if [[ "$removal_status" -eq 2 ]]; then
+      continue
+    fi
+    fail "unable to reclaim stale runner lock: ${lock_dir}"
+  done
+  fail "unable to acquire or reclaim runner lock: ${lock_dir}"
+}
+
 run_child() {
   local child_status
+  local completed_child_pid=""
   critical_section=1
   set -m
   "$@" &
   child_pid=$!
+  completed_child_pid="$child_pid"
+  if [[ "$lock_owned" -eq 1 ]]; then
+    printf '%s\n' "$child_pid" > "$lock_child_pid_file"
+  fi
   set +m
   critical_section=0
   service_pending_signal
@@ -34,6 +164,10 @@ run_child() {
     child_status=0
   else
     child_status=$?
+  fi
+  if [[ -f "$lock_child_pid_file" ]] &&
+     [[ "$(< "$lock_child_pid_file")" == "$completed_child_pid" ]]; then
+    rm -f -- "$lock_child_pid_file"
   fi
   child_pid=""
   return "$child_status"
@@ -59,12 +193,14 @@ terminate_child_group() {
     kill "$killer_pid" 2>/dev/null || true
     wait "$killer_pid" 2>/dev/null || true
   fi
+  rm -f -- "$lock_child_pid_file"
   child_pid=""
 }
 
 cleanup() {
   local original_status=$?
   local cleanup_status=0
+  local owner_pid=""
   trap - EXIT
   trap '' INT TERM
 
@@ -80,7 +216,15 @@ cleanup() {
   fi
 
   if [[ "$lock_owned" -eq 1 ]]; then
-    rmdir "$lock_dir" 2>/dev/null || true
+    owner_pid=""
+    if [[ -f "$lock_pid_file" ]]; then
+      owner_pid="$(< "$lock_pid_file")"
+    fi
+    if [[ "$owner_pid" == "$$" ]]; then
+      rm -f -- "$lock_child_pid_file"
+      rm -f -- "$lock_pid_file"
+      rmdir "$lock_dir" 2>/dev/null || true
+    fi
     lock_owned=0
   fi
   if [[ "$original_status" -ne 0 ]]; then
@@ -111,6 +255,8 @@ service_pending_signal() {
 }
 
 [[ "$#" -eq 0 ]] || fail "arguments are not supported."
+[[ -n "$runtime_tmp_dir" && -d "$runtime_tmp_dir" && -w "$runtime_tmp_dir" ]] ||
+  fail "no writable temporary directory is available for the runner lock."
 [[ -x "$python_bin" ]] || fail "missing .venv; run make install first."
 [[ -f "${repo_root}/jira_server.py" && -f "${repo_root}/backend/db/alembic.ini" ]] ||
   fail "runner path does not resolve to a source checkout."
@@ -166,16 +312,7 @@ export COMPOSE_DISABLE_ENV_FILE=1
 trap cleanup EXIT
 trap 'handle_signal 130' INT
 trap 'handle_signal 143' TERM
-critical_section=1
-if mkdir "$lock_dir" 2>/dev/null; then
-  lock_owned=1
-else
-  critical_section=0
-  service_pending_signal
-  fail "another runner is active or a stale runner lock requires inspection: ${lock_dir}"
-fi
-critical_section=0
-service_pending_signal
+acquire_lock
 
 volume_names="$(
   "${docker_cli[@]}" volume ls --format '{{.Name}}'

--- a/tests/test_local_postgresql_runner.py
+++ b/tests/test_local_postgresql_runner.py
@@ -136,6 +136,40 @@ fi
 exec /bin/mkdir "$@"
 '''
 
+FAILING_LOCK_MKDIR_STUB = r'''#!/usr/bin/env bash
+set -u
+if [[ "$1" == "$FAKE_LOCK_DIR" ]]; then
+  exit 1
+fi
+exec /bin/mkdir "$@"
+'''
+
+PS_STUB = r'''#!/usr/bin/env bash
+set -u
+if [[ "$*" == *"-o command="* ]]; then
+  target_pid="$2"
+  if [[ -n "${FAKE_UNRELATED_PID:-}" && "$target_pid" == "$FAKE_UNRELATED_PID" ]]; then
+    printf '%s\n' "sleep 30"
+  else
+    printf 'bash %s\n' "$FAKE_RUNNER_PATH"
+  fi
+  exit 0
+fi
+exit 98
+'''
+
+RMDIR_STUB = r'''#!/usr/bin/env bash
+set -u
+if [[ "$1" == "$FAKE_LOCK_DIR" &&
+      -n "${FAKE_LOCK_DISAPPEAR_FILE:-}" &&
+      ! -e "$FAKE_LOCK_DISAPPEAR_FILE" ]]; then
+  /bin/rmdir "$1"
+  : > "$FAKE_LOCK_DISAPPEAR_FILE"
+  exit 1
+fi
+exec /bin/rmdir "$@"
+'''
+
 
 class LocalPostgresqlRunnerProcessTests(unittest.TestCase):
     def setUp(self):
@@ -150,7 +184,7 @@ class LocalPostgresqlRunnerProcessTests(unittest.TestCase):
         shutil.copy2(ROOT / "runners/local/compose.yaml", self.runner_dir / "compose.yaml")
         runner_path = self.runner_dir / "run.sh"
         runner_source = runner_path.read_text(encoding="utf8")
-        production_lock = 'readonly lock_dir="/tmp/jira-planning-local-runner.lock"'
+        production_lock = 'readonly lock_dir="${runtime_tmp_dir}/jira-planning-local-runner.lock"'
         if runner_source.count(production_lock) != 1:
             raise AssertionError("production lock declaration changed")
         runner_path.write_text(
@@ -171,6 +205,7 @@ class LocalPostgresqlRunnerProcessTests(unittest.TestCase):
         self.fake_bin = base / "fake-bin"
         self.fake_bin.mkdir()
         self._write_executable(self.fake_bin / "docker", DOCKER_STUB)
+        self._write_executable(self.fake_bin / "ps", PS_STUB)
 
         self.log = base / "runner.log"
         self.child_pid_file = base / "child.pid"
@@ -181,6 +216,8 @@ class LocalPostgresqlRunnerProcessTests(unittest.TestCase):
         self.env.update({
             "PATH": f"{self.fake_bin}{os.pathsep}{self.env.get('PATH', '')}",
             "RUNNER_LOG": str(self.log),
+            "FAKE_RUNNER_PATH": str(runner_path),
+            "FAKE_LOCK_DIR": str(self.lock_dir),
             "FAKE_CHILD_PID_FILE": str(self.child_pid_file),
             "FAKE_GRANDCHILD_PID_FILE": str(self.grandchild_pid_file),
             "TMPDIR": str(base),
@@ -273,6 +310,14 @@ class LocalPostgresqlRunnerProcessTests(unittest.TestCase):
         for stream in (process.stdout, process.stderr):
             if stream is not None and not stream.closed:
                 stream.close()
+        try:
+            (self.lock_dir / "runner.pid").unlink()
+        except FileNotFoundError:
+            pass
+        try:
+            (self.lock_dir / "child.pid").unlink()
+        except FileNotFoundError:
+            pass
         try:
             self.lock_dir.rmdir()
         except FileNotFoundError:
@@ -611,13 +656,12 @@ class LocalPostgresqlRunnerProcessTests(unittest.TestCase):
         self.assertNotIn(" down --timeout 10", self._log_text())
         self._assert_lock_released()
 
-    def test_second_checkout_with_different_tmpdir_cannot_mutate(self):
+    def test_second_runner_stops_first_then_starts(self):
         first_log = self.log.parent / "first.log"
         first_env = self.env.copy()
         first_env.update({
             "RUNNER_LOG": str(first_log),
             "FAKE_APP_SLEEP": "1",
-            "TMPDIR": str(self.log.parent / "tmp-one"),
         })
         first = self._start_process(env=first_env)
         try:
@@ -632,17 +676,145 @@ class LocalPostgresqlRunnerProcessTests(unittest.TestCase):
             second_log = self.log.parent / "second.log"
             second = self._run(
                 RUNNER_LOG=second_log,
-                TMPDIR=self.log.parent / "tmp-two",
             )
             second_output = second_log.read_text(encoding="utf8")
-            self.assertNotEqual(second.returncode, 0)
-            self.assertIn("another runner is active", second.stderr)
-            self.assertNotIn(" up --detach --wait", second_output)
-            self.assertNotIn(" down --timeout 10", second_output)
-
-            first.send_signal(signal.SIGTERM)
-            first.communicate(timeout=8)
+            self.assertIsNotNone(first.poll(), second.stderr)
+            _, first_stderr = first.communicate(timeout=8)
+            self.assertEqual(first.returncode, 143, first_stderr)
+            self.assertEqual(second.returncode, 0, second.stderr)
+            self.assertIn("replacing runner", second.stderr)
+            self.assertIn(" up --detach --wait", second_output)
+            self._assert_down_once(second_output)
             self._assert_down_once(first_log.read_text(encoding="utf8"))
+            self._assert_lock_released()
+        finally:
+            self._cleanup_process(first)
+
+    def test_malformed_pid_lock_is_reclaimed(self):
+        self.lock_dir.mkdir()
+        (self.lock_dir / "runner.pid").write_text("not-a-pid\n", encoding="utf8")
+
+        result = self._run()
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("reclaiming stale runner lock", result.stderr)
+        self.assertIn(" up --detach --wait", self._log_text())
+        self._assert_lock_released()
+
+    def test_empty_lock_from_previous_runner_is_reclaimed(self):
+        self.lock_dir.mkdir()
+
+        result = self._run()
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("reclaiming stale runner lock", result.stderr)
+        self._assert_lock_released()
+
+    def test_lock_creation_failure_exits_once_without_stale_reclaim_loop(self):
+        self._write_executable(self.fake_bin / "mkdir", FAILING_LOCK_MKDIR_STUB)
+
+        result = self._run()
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertEqual(result.stderr.count("reclaiming stale runner lock"), 0)
+        self.assertIn("unable to create runner lock", result.stderr)
+        self._assert_lock_released()
+
+    def test_unreclaimable_stale_lock_fails_once_without_retry_loop(self):
+        runner_path = self.runner_dir / "run.sh"
+        source = runner_path.read_text(encoding="utf8")
+        acquisition_limit = 'while [[ "$acquisition_attempt" -lt 20 ]]'
+        self.assertEqual(source.count(acquisition_limit), 1)
+        runner_path.write_text(
+            source.replace(
+                acquisition_limit,
+                'while [[ "$acquisition_attempt" -lt 2 ]]',
+                1,
+            ),
+            encoding="utf8",
+        )
+        self.lock_dir.mkdir()
+        (self.lock_dir / "runner.pid").write_text("not-a-pid\n", encoding="utf8")
+        unexpected_file = self.lock_dir / "unexpected"
+        unexpected_file.write_text("occupied\n", encoding="utf8")
+        try:
+            started_at = time.monotonic()
+            result = self._run()
+
+            self.assertNotEqual(result.returncode, 0)
+            self.assertLess(time.monotonic() - started_at, 3)
+            self.assertEqual(result.stderr.count("reclaiming stale runner lock"), 1)
+            self.assertIn("unable to reclaim stale runner lock", result.stderr)
+        finally:
+            unexpected_file.unlink(missing_ok=True)
+            (self.lock_dir / "runner.pid").unlink(missing_ok=True)
+            self.lock_dir.rmdir()
+
+    def test_lock_disappearing_during_reclaim_is_treated_as_success(self):
+        disappeared_file = self.log.parent / "lock-disappeared"
+        self._write_executable(self.fake_bin / "rmdir", RMDIR_STUB)
+        self.lock_dir.mkdir()
+        (self.lock_dir / "runner.pid").write_text("not-a-pid\n", encoding="utf8")
+
+        result = self._run(FAKE_LOCK_DISAPPEAR_FILE=disappeared_file)
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(result.stderr.count("reclaiming stale runner lock"), 1)
+        self.assertNotIn("unable to reclaim stale runner lock", result.stderr)
+        self._assert_lock_released()
+
+    def test_live_unrelated_pid_is_not_signalled_when_lock_is_reclaimed(self):
+        unrelated = subprocess.Popen(["sleep", "30"])
+        self.addCleanup(self._cleanup_process, unrelated)
+        self.lock_dir.mkdir()
+        (self.lock_dir / "runner.pid").write_text(
+            f"{unrelated.pid}\n", encoding="utf8",
+        )
+        try:
+            result = self._run(FAKE_UNRELATED_PID=unrelated.pid)
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertIn("reclaiming stale runner lock", result.stderr)
+            self.assertIsNone(unrelated.poll())
+            self._assert_lock_released()
+        finally:
+            self._cleanup_process(unrelated)
+
+    def test_replacement_escalates_when_first_runner_cannot_handle_term(self):
+        first_log = self.log.parent / "stopped-first.log"
+        first_env = self.env.copy()
+        first_env.update({
+            "RUNNER_LOG": str(first_log),
+            "FAKE_APP_SLEEP": "1",
+            "FAKE_APP_GRANDCHILD": "1",
+        })
+        first = self._start_process(env=first_env)
+        try:
+            deadline = time.monotonic() + 5
+            while time.monotonic() < deadline:
+                if (
+                    self.lock_dir.exists()
+                    and first_log.exists()
+                    and "jira_server.py" in first_log.read_text(encoding="utf8")
+                ):
+                    break
+                time.sleep(0.05)
+            else:
+                self.fail("first runner did not acquire the lock")
+            (self.lock_dir / "runner.pid").write_text(
+                f"{first.pid}\n", encoding="utf8",
+            )
+            first.send_signal(signal.SIGSTOP)
+
+            result = self._run()
+            self.assertIsNotNone(first.poll(), result.stderr)
+            _, first_stderr = first.communicate(timeout=8)
+
+            self.assertEqual(first.returncode, -signal.SIGKILL, first_stderr)
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertIn("did not stop; sending KILL", result.stderr)
+            self._assert_pid_exits(self.child_pid_file)
+            self._assert_pid_exits(self.grandchild_pid_file)
             self._assert_lock_released()
         finally:
             self._cleanup_process(first)

--- a/tests/test_postgresql_runner_contract.py
+++ b/tests/test_postgresql_runner_contract.py
@@ -51,7 +51,9 @@ class LocalRunnerSourceContractTests(unittest.TestCase):
             "DEBUG_MODE=false",
             "--project-name",
             'readonly project_name="jira-planning-local"',
-            'readonly lock_dir="/tmp/jira-planning-local-runner.lock"',
+            'runtime_tmp_dir="/tmp"',
+            "getconf DARWIN_USER_TEMP_DIR",
+            'readonly lock_dir="${runtime_tmp_dir}/jira-planning-local-runner.lock"',
             "--project-directory",
             "--env-file",
             "/dev/null",
@@ -326,18 +328,13 @@ class RunnerIsolationContractTests(unittest.TestCase):
             source,
         )
 
-    def test_local_guide_documents_narrow_stale_lock_recovery(self):
+    def test_local_guide_documents_runner_replacement_and_stale_recovery(self):
         source = read("runners/local/README.md")
-        self.assertIn("no runner process is active", source)
-        self.assertIn(
-            "no exact `jira-planning-local` Compose project, container, "
-            "network, or volume user is active",
-            source,
-        )
-        self.assertIn(
-            "rmdir /tmp/jira-planning-local-runner.lock",
-            source,
-        )
+        self.assertIn("stops that runner and waits for its cleanup", source)
+        self.assertIn("reclaims stale or corrupt lock metadata", source)
+        self.assertIn("reports the problem once and exits", source)
+        self.assertIn("does not signal unrelated processes", source)
+        self.assertNotIn("rmdir /tmp/jira-planning-local-runner.lock", source)
         self.assertIn("Do not use broad Docker prune commands", source)
         self.assertIn(
             "`backend.db.reset_local` as lifecycle cleanup",


### PR DESCRIPTION
## Summary

- Replace an active local PostgreSQL runner safely through validated PID ownership, bounded TERM/KILL handling, and child process-group cleanup.
- Reclaim stale or corrupt locks without signalling unrelated processes, and handle concurrent lock disappearance and unavailable /tmp paths.
- Document the runner behavior, its executed work artifact, and MRT025 publication safeguards.
- Add a blocking repository publication gate for commit history, file scope, PR body transport, remote verification, and CI reporting.

## Verification

- `bash -n runners/local/run.sh` passed.
- The focused local-runner and contract suite passed 46/46 tests.
- The three process cases that failed under the latest long-suite load passed 3/3 when rerun in isolation.
- A prior full JSON-file/basic run with the same runner implementation passed all 1,545 tests with 9 skipped.
- The latest full JSON-file/basic run completed 1,545 tests with 2 failures, 1 error, and 9 skipped; the failures were the three process cases above timing out or missing their five-second readiness marker under full-suite load.
- `git diff --check` passed.
- The branch contains one commit and exactly eight intended files relative to `main`.
